### PR TITLE
Extend BareMetalHost CRD for Dell PowerEdge Server BIOS Config

### DIFF
--- a/design/bios-config.md
+++ b/design/bios-config.md
@@ -61,7 +61,8 @@ The proposal is to set/unset the BIOS configuration values using vendor drivers 
  
 ### Implementation Details/Notes/Constraints 
 All the BIOS related attributes or fields will come under the sub-section called ```bios``` in spec. The values for each attribute can be a boolean or a string. The vendor driver type to implement this configuration is not to be specified separetely as it is already known from the bmc sub-section.
-Initially, the BIOS configuration can be applied using the controller types idrac and irmc
+
+The proposed BMH looks like the following, given the three supported parameters
 
 ```yaml
 apiVersion: metal3.io/v1alpha1
@@ -75,15 +76,29 @@ spec:
    credentialsName: bm0-bmc-secret
  bootMACAddress: 52:54:00:b7:b2:6f	
  bios:
-   EnableSriovGlobal: false
-   EnableVirtualization: false
-   EnableHyperThreading: true
-   EnableAdjCacheLine: false
+   sriovEnabled: false
+   virtualizationDisabled: false
+   simultaneousMultithreadingDisabled: false
 ```
 
-The user can only specify the BIOS values related to the BMC type being used as they will be validated accordingly.
+The booleans are to be implemented as pointers, allowing us to detect when user has asked for a change.
 
-One gotcha to this is about hiding the vendor sprawl in the parameter names and coming up with generic titles for the config params. This would then need to be handled in the operator code (the vendor-specific implementation for Ironic API calls). Meaning, it will still be required to map these *generic* names to the actual parameter names in the API call for it to function.
+To handle settings that are vendor specific, the following format can be used:
+
+```yaml
+bios:
+   attr: value
+   attr: value
+   vendor:
+      vendor_attr: value
+      vendor_attr: value
+```
+
+The proposal only deals with the generic BIOS configurations (listed above), and nothing vendor specific will be developed/tested, although, formatting for those will be part of this specification.
+
+One gotcha to this is about hiding the vendor sprawl in the parameter names and coming up with generic titles for the config params. Have had many discussions on this, and we have agreed to the format specified above.
+
+This would then need to be handled in the operator code (the vendor-specific implementation for Ironic API calls). Meaning, it will still be required to map these *generic* names to the actual parameter names in the API call for it to function.
 
 ### Risks and Mitigations
 
@@ -120,7 +135,7 @@ The code changes required would entail
 
 - Unit tests for the functions
 
-- Deployment testing with actual hardware
+- Integration testing with actual hardware
 
 
 ### Upgrade / Downgrade Strategy

--- a/design/bios-config.md
+++ b/design/bios-config.md
@@ -60,8 +60,8 @@ We need this document to specify the typical usage of BIOS YAML attributes in th
 The proposal is to set/unset the BIOS configuration values using vendor drivers available for each BMC type. For this purpose, new YAML attributes are to be introduced in the BareMetalHost spec. 
  
 ### Implementation Details/Notes/Constraints 
-All the BIOS related attributes or key value pairs or fields will come under the sub-section called 'bios' in spec. The values for each attribute can be a boolean or a string. The vendor driver type to implement this configuration is not to be specified separetely as it is already known from the bmc sub-section.
-Initially, the BIOS configuration can be applied using the following controller types idrac and irmc
+All the BIOS related attributes or fields will come under the sub-section called ```bios``` in spec. The values for each attribute can be a boolean or a string. The vendor driver type to implement this configuration is not to be specified separetely as it is already known from the bmc sub-section.
+Initially, the BIOS configuration can be applied using the controller types idrac and irmc
 
 ```yaml
 apiVersion: metal3.io/v1alpha1
@@ -84,7 +84,7 @@ spec:
 
 The user can only specify the BIOS values related to the BMC type being used as they will be validated accordingly.
 
-One gotcha to this is about hiding the vendor sprawl in the parameter names and coming up with generic titles for the config params. This would then need to be handled in the operator code (the vendor-specific implementation for Ironic API calls). Meaning, it will still be required to map these 'generic' names to the actual parameter names in the API call for it to function.
+One gotcha to this is about hiding the vendor sprawl in the parameter names and coming up with generic titles for the config params. This would then need to be handled in the operator code (the vendor-specific implementation for Ironic API calls). Meaning, it will still be required to map these *generic* names to the actual parameter names in the API call for it to function.
 
 ### Risks and Mitigations
 
@@ -92,7 +92,7 @@ None
 
 ## Design Details
 
-The BIOS config is only possible when the host is in cleaning state and the input is to be given as a set of cleaning steps
+The BIOS config is only possible when the host is in cleaning state and the input is to be given as a set of cleaning steps.
 
 The code changes required would entail 
 - Creating a go struct with the BIOS configs in the ```ironic.go (pkg/provisioner/ironic/ironic.go)```
@@ -105,7 +105,7 @@ The code changes required would entail
 
 - Extend the BareMetalHost CRD with the new parameters for iDRAC and Redfish BMC types.
 
-- Validation of incoming values 
+- Validation of input values in the YAML parameters
 
 - A function to handle the cleaning steps related to BIOS configuration and its implementation
 
@@ -146,5 +146,6 @@ None
 
 - [PR in baremetal-operator repo with discussion on this topic](https://github.com/metal3-io/baremetal-operator/pull/302)
 
-[Issue #364 in the baremetal-operator repo was the starting point for this]([https://github.com/metal3-io/baremetal-operator/issues/364)
-[Issue #206 in the baremetal-operator repo was a similar discussion between the community and Fujitsu guys](https://github.com/metal3-io/baremetal-operator/issues/206)
+- [Issue #364 in the baremetal-operator repo was the starting point for this](https://github.com/metal3-io/baremetal-operator/issues/364)
+
+- [Issue #206 in the baremetal-operator repo was a similar discussion between the community and Fujitsu guys](https://github.com/metal3-io/baremetal-operator/issues/206)

--- a/design/bios-config.md
+++ b/design/bios-config.md
@@ -75,18 +75,20 @@ spec:
    address: idrac://192.168.122.1:6230/
    credentialsName: bm0-bmc-secret
  bootMACAddress: 52:54:00:b7:b2:6f	
- bios:
+ firmware:
    sriovEnabled: false
    virtualizationDisabled: false
    simultaneousMultithreadingDisabled: false
 ```
+
+We've decided to name the section "firmware" to make it future proof, since the notion of BIOS is irrelevant outside of x86 architectures. This is also to make the distinction that BIOS != UEFI. Moreover, in the future, this can be extended to add extra information, for instance current firmware version etc. Then it can be decided to restructure this section.
 
 The booleans are to be implemented as pointers, allowing us to detect when user has asked for a change.
 
 To handle settings that are vendor specific, the following format can be used:
 
 ```yaml
-bios:
+firmware:
    attr: value
    attr: value
    vendor:

--- a/design/bios-config.md
+++ b/design/bios-config.md
@@ -76,7 +76,6 @@ spec:
  bootMACAddress: 52:54:00:b7:b2:6f	
  bios:
    EnableSriovGlobal: false
-   BootMode: uefi
    EnableVirtualization: false
    EnableHyperThreading: true
    EnableAdjCacheLine: false

--- a/design/bios-config.md
+++ b/design/bios-config.md
@@ -22,9 +22,6 @@ provisional
          * [Goals](#goals)
          * [Non-Goals](#non-goals)
       * [Proposal](#proposal)
-         * [User Stories [optional]](#user-stories-optional)
-            * [Story 1](#story-1)
-            * [Story 2](#story-2)
          * [Implementation Details/Notes/Constraints [optional]](#implementation-detailsnotesconstraints-optional)
          * [Risks and Mitigations](#risks-and-mitigations)
       * [Design Details](#design-details)
@@ -61,18 +58,10 @@ We need this document to specify the typical usage of BIOS YAML attributes in th
 
 ## Proposal
 The proposal is to set/unset the BIOS configuration values using vendor drivers available for each BMC type. For this purpose, new YAML attributes are to be introduced in the BareMetalHost spec. 
-
-This is based on the discussions with metal3 community on the following issues:
-#364
-[https://github.com/metal3-io/baremetal-operator/issues/364]
-#206
-[https://github.com/metal3-io/baremetal-operator/issues/206]
  
 ### Implementation Details/Notes/Constraints 
 All the BIOS related attributes or key value pairs or fields will come under the sub-section called 'bios' in spec. The values for each attribute can be a boolean or a string. The vendor driver type to implement this configuration is not to be specified separetely as it is already known from the bmc sub-section.
-Initially, the BIOS configuration can be applied using the following controller types
-- idrac
-- irmc
+Initially, the BIOS configuration can be applied using the following controller types idrac and irmc
 
 ```yaml
 apiVersion: metal3.io/v1alpha1
@@ -95,7 +84,7 @@ spec:
 
 The user can only specify the BIOS values related to the BMC type being used as they will be validated accordingly.
 
-One gotcha to this is about hiding the vendor sprawl in the parameter names and coming up with generic titles for the config params. This would then need to be handled in the operator code (the vendor-specific implementation for Ironic API calls)
+One gotcha to this is about hiding the vendor sprawl in the parameter names and coming up with generic titles for the config params. This would then need to be handled in the operator code (the vendor-specific implementation for Ironic API calls). Meaning, it will still be required to map these 'generic' names to the actual parameter names in the API call for it to function.
 
 ### Risks and Mitigations
 
@@ -106,11 +95,11 @@ None
 The BIOS config is only possible when the host is in cleaning state and the input is to be given as a set of cleaning steps
 
 The code changes required would entail 
-- Creating a go struct with the BIOS configs in the ironic.go (pkg/provisioner/ironic/ironic.go)
+- Creating a go struct with the BIOS configs in the ```ironic.go (pkg/provisioner/ironic/ironic.go)```
 
-- Creating a new function to validate config params and build a final JSON object, called 'buildBIOSConfig' in ironic.go
+- Creating a new function to validate config params and build a final JSON object, called ```buildBIOSConfig``` in ```ironic.go```
 
-- Creating a new function to build clean steps for BIOS config called 'buildBIOSCleanSteps' in ironic.go
+- Creating a new function to build clean steps for BIOS config called ```buildBIOSCleanSteps``` in ```ironic.go```
 
 ### Work Items
 
@@ -155,3 +144,7 @@ None
 
 ## References
 
+- [PR in baremetal-operator repo with discussion on this topic](https://github.com/metal3-io/baremetal-operator/pull/302)
+
+[Issue #364 in the baremetal-operator repo was the starting point for this]([https://github.com/metal3-io/baremetal-operator/issues/364)
+[Issue #206 in the baremetal-operator repo was a similar discussion between the community and Fujitsu guys](https://github.com/metal3-io/baremetal-operator/issues/206)

--- a/design/bios-config.md
+++ b/design/bios-config.md
@@ -91,7 +91,7 @@ None
 
 ## Design Details
 
-The BIOS config is only possible when the host is in cleaning state and the input is to be given as a set of cleaning steps.
+This BIOS config will be implemented through Ironic ```bios-interface```. These settings will only be applied to a host when it is being provisioned with an image. A change in BIOS configs on a host with running workload will NOT trigger reprovisioning.
 
 The code changes required would entail 
 - Creating a go struct with the BIOS configs in the ```ironic.go (pkg/provisioner/ironic/ironic.go)```
@@ -102,7 +102,7 @@ The code changes required would entail
 
 ### Work Items
 
-- Extend the BareMetalHost CRD with the new parameters for iDRAC and Redfish BMC types.
+- Extend the BareMetalHost CRD with the new parameters for iDRAC BMC type.
 
 - Validation of input values in the YAML parameters
 
@@ -119,8 +119,6 @@ The code changes required would entail
 ### Test Plan
 
 - Unit tests for the functions
-
-- Mock deployment testing with vBMC
 
 - Deployment testing with actual hardware
 

--- a/design/bios-config.md
+++ b/design/bios-config.md
@@ -1,0 +1,157 @@
+<!--
+ This work is licensed under a Creative Commons Attribution 3.0
+ Unported License.
+
+ http://creativecommons.org/licenses/by/3.0/legalcode
+-->
+
+# bios-config
+
+## Status
+
+provisional
+
+## Table of Contents
+
+<!--ts-->
+   * [Title](#title)
+      * [Status](#status)
+      * [Table of Contents](#table-of-contents)
+      * [Summary](#summary)
+      * [Motivation](#motivation)
+         * [Goals](#goals)
+         * [Non-Goals](#non-goals)
+      * [Proposal](#proposal)
+         * [User Stories [optional]](#user-stories-optional)
+            * [Story 1](#story-1)
+            * [Story 2](#story-2)
+         * [Implementation Details/Notes/Constraints [optional]](#implementation-detailsnotesconstraints-optional)
+         * [Risks and Mitigations](#risks-and-mitigations)
+      * [Design Details](#design-details)
+         * [Work Items](#work-items)
+         * [Dependencies](#dependencies)
+         * [Test Plan](#test-plan)
+         * [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+         * [Version Skew Strategy](#version-skew-strategy)
+      * [Drawbacks [optional]](#drawbacks-optional)
+      * [Alternatives [optional]](#alternatives-optional)
+      * [References](#references)
+
+<!-- Added by: stack, at: 2019-02-15T11:41-05:00 -->
+
+<!--te-->
+
+## Summary
+
+This document explains the usage of YAML attributes for BIOS configuration for the BareMetalHost of the BMO. These configurations will be applied to the host according to the vendor's BMC driver being used by Ironic.
+
+## Motivation
+
+We need this document to specify the typical usage of BIOS YAML attributes in the BareMetalHost YAML. 
+
+
+### Goals
+
+1. To agree on the format of the attributes that are to be supported as a starting point
+2. To keep the attribute naming vendor agnostic
+
+### Non-Goals
+
+1. To list every attribute for every vendor exhaustively
+
+## Proposal
+The proposal is to set/unset the BIOS configuration values using vendor drivers available for each BMC type. For this purpose, new YAML attributes are to be introduced in the BareMetalHost spec. 
+
+This is based on the discussions with metal3 community on the following issues:
+#364
+[https://github.com/metal3-io/baremetal-operator/issues/364]
+#206
+[https://github.com/metal3-io/baremetal-operator/issues/206]
+ 
+### Implementation Details/Notes/Constraints 
+All the BIOS related attributes or key value pairs or fields will come under the sub-section called 'bios' in spec. The values for each attribute can be a boolean or a string. The vendor driver type to implement this configuration is not to be specified separetely as it is already known from the bmc sub-section.
+Initially, the BIOS configuration can be applied using the following controller types
+- idrac
+- irmc
+
+```yaml
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+ name: bm0
+spec:
+ online: true
+ bmc:
+   address: idrac://192.168.122.1:6230/
+   credentialsName: bm0-bmc-secret
+ bootMACAddress: 52:54:00:b7:b2:6f	
+ bios:
+   EnableSriovGlobal: false
+   BootMode: uefi
+   EnableVirtualization: false
+   EnableHyperThreading: true
+   EnableAdjCacheLine: false
+```
+
+The user can only specify the BIOS values related to the BMC type being used as they will be validated accordingly.
+
+One gotcha to this is about hiding the vendor sprawl in the parameter names and coming up with generic titles for the config params. This would then need to be handled in the operator code (the vendor-specific implementation for Ironic API calls)
+
+### Risks and Mitigations
+
+None
+
+## Design Details
+
+The BIOS config is only possible when the host is in cleaning state and the input is to be given as a set of cleaning steps
+
+The code changes required would entail 
+- Creating a go struct with the BIOS configs in the ironic.go (pkg/provisioner/ironic/ironic.go)
+
+- Creating a new function to validate config params and build a final JSON object, called 'buildBIOSConfig' in ironic.go
+
+- Creating a new function to build clean steps for BIOS config called 'buildBIOSCleanSteps' in ironic.go
+
+### Work Items
+
+- Extend the BareMetalHost CRD with the new parameters for iDRAC and Redfish BMC types.
+
+- Validation of incoming values 
+
+- A function to handle the cleaning steps related to BIOS configuration and its implementation
+
+- Unit tests for all the work above
+
+
+### Dependencies
+
+- Ironic
+- Baremetal-operator
+
+### Test Plan
+
+- Unit tests for the functions
+
+- Mock deployment testing with vBMC
+
+- Deployment testing with actual hardware
+
+
+### Upgrade / Downgrade Strategy
+
+None
+
+### Version Skew Strategy
+
+None
+
+## Drawbacks
+
+None
+
+## Alternatives
+
+None
+
+## References
+


### PR DESCRIPTION
For Dell PowerEdge servers with iDRAC NDC, the BIOS can be configured using the ```idrac``` vendor interface which is available in Ironic. We would like to propose new YAML attributes to setup BIOS with this vendor driver.