### PR TITLE
Update design of Machine Remediation

### DIFF
--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -95,7 +95,7 @@ itself, allowing it to host workloads.
 
 ## Proposal
 
-This proposal calls for a new machine remediation controller (MRC) in CAPBM
+This proposal calls for a new machine remediation controller (MRC) in CAPM3
 which watches for the presence of a `host.metal3.io/external-remediation` Machine
 annotation. If present, the controller will locate the Machine
 and BareMetalHost host objects via their annotations, and will annotate the BareMetalHost

--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -99,10 +99,10 @@ This proposal calls for a new machine remediation controller (MRC) in CAPM3
 which watches for the presence of a `host.metal3.io/external-remediation` Machine
 annotation. If present, the controller will locate the Machine
 and BareMetalHost host objects via their annotations, and will annotate the BareMetalHost
-CR with a `reboot.metal3.io/machine-remediation`. Upon host power off, the controller
-will delete the node and then remove the annotation, to power on the host by
-utilizing [Baremetal-Operator reboot API](https://github.com/metal3-io/metal3-docs/blob/master/design/reboot-interface.md).
-
+CR with a `reboot.metal3.io/machine-remediation` to power cycle the host by
+utilizing the [Baremetal-Operator reboot API](https://github.com/metal3-io/metal3-docs/blob/master/design/reboot-interface.md).
+Upon host power off, the controller will delete the node and then remove the annotation,
+allowing it to be powered back on.
 After restart/crash of the new controller it will check for
 `reboot.metal3.io/machine-remediation` annotation on all hosts,
 and continue remediation process, to make sure that such host is

--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -111,17 +111,21 @@ not left in powered off state.
 ## Assumptions
 
 MHC checks that each machine has a node, and if it doesn't after some timeout,
-it will mark the machine as unhealthy. There could be situations where this timeout
-expires few seconds after MRC powered on the machine, resulting in one or more
-redundant reboot(s).
-Current MHC implementation checks that `now() - Machine.LastUpdated < timeout`.
-MRC deletes the unhealthy node, which updates `Machine.LastUpdated`.
-We assume that this implementation won't change.
+it will mark the machine as unhealthy. If this timeout expires soon after the MRC powered
+on the host, it could result in one or more redundant reboot(s).
+However, the current MHC implementation checks that `now() - Machine.LastUpdated < timeout`
+and the MRC deletes the unhealthy node, which updates `Machine.LastUpdated`.
+
+We assume that this implementation won't change, that `timeout` is set long enough
+for a node to be both provisioned *and* rebooted, which implies that any `Node` 
+hitting this timeout is truly malfunctioning.
+
+Further, we require that equivalent functionality will exist in parallel implementations.
 
 In addition, MRC has some operations to perform between node deletion (which triggers
 update of `Machine.LastUpdated`) to powering on the host, and these operations
 are also counted against that timeout. These operations are removing
-MAO's annotation and removing the reboot annotation. We assume that this
+the unhealthy annotation from the Machine and removing the reboot annotation. We assume that this
 time is negligible, especially compared to a newly provisioned host, and in case of
 temporary failure to remove one of the annotations we will risk in additional reboot.
 

--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -159,6 +159,26 @@ hosts referenced by node-less machines
 `host.metal3.io/external-remediation` annotation (by removing
 `reboot.metal3.io/machine-remediation` annotation from host)
 
+See truth table below:
+
+|Node Ref exists?|Needs remediation annotation|Powered on?|Reboot annotation|MRC action|
+|:-:|:-:|:-:|:-:|---|
+|0|1|1|0|Add reboot annotation|
+|1|1|1|0|Add reboot annotation|
+|1|1|0|1|Delete node|
+|0|0|1|0|nothing|
+|0|0|1|1|nothing|
+|0|1|0|0|nothing|
+|0|1|1|1|nothing|
+|1|0|0|0|nothing|
+|1|0|1|0|nothing|
+|1|0|1|1|nothing|
+|1|1|0|0|nothing|
+|1|1|1|1|nothing|
+|0|1|0|1|Remove needs-remediation annoation|
+|0|0|0|1|Remove reboot annotation|
+|1|0|0|1|Remove reboot annotation|
+
 ### Work Items
 
 - Create a new machine remediation controller in openshift/CAPBM repo

--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -185,13 +185,16 @@ No changes are required to preserve the existing behaviour.
 
 ### Version Skew Strategy
 
-If CAPBM will be downgraded and BMO version will include the reboot functionality,
-we might end with a powered off host. This can happen if remediation process started,
-MRC requested for a power off by adding suffixed reboot annotation, and then CAPBM
-being downgraded to a version without MRC. There will be no one to remove that annotation
-and BMO will keep the host in powered off state until annotation removal.
-This will be solved as soon as the version skew is gone and they both use either
-reboot-supported versions or not at all.
+CAPBM and BMO are delivered via the same image (both are installed by MAO, but running
+in a different pod), therefore an upgrade or downgrade affecting one component will
+eventually be applied to the other and any version skew is temporary.
+During the transient case that CAPBM does not include the MRC, Host can be left in powered
+off state, since MRC could add reboot annotation, and then it get downgraded, and there will
+be no controller to remove the reboot annotation.
+During the transient case that BMO does not support the reboot API, MRC could request for a reboot,
+which won't commence until BMO upgrades to a version which supports reboot annotation.
+In both cases, the impact is just delayed remediation and will be resolved once there's
+no version skew. 
 
 ## Drawbacks [optional]
 

--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -167,7 +167,8 @@ hosts referenced by node-less machines
 
 ### Work Items
 
-- Create a new machine remediation controller in CAPBM repo
+- Create a new machine remediation controller in openshift/CAPBM repo
+- Backport to upstream
 
 ### Dependencies
 

--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -147,11 +147,6 @@ RBAC rules will be needed to ensure that only specific roles can trigger
 machines to reboot. Without this, the system would be exposed to DoS style
 attacks.
 
-There's a possibility that the unhealthy node is running the MRC/MAO/BMO pod, which
-might lead to unexpected behaviours such as MHC not able to annotate the machine,
-or BMO not able to control the power of the host, or even MRC could delete itself.
-To mitigate this we need a multiple copies with a lock for each component involved.
-
 ## Design Details
 
 MRC will:

--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -9,7 +9,7 @@
 
 ## Status
 
-implemented
+implementable
 
 ## Table of Contents
 
@@ -95,35 +95,52 @@ itself, allowing it to host workloads.
 
 ## Proposal
 
-This proposal calls for a new controller which watches for the presence of a
-specific Node annotation.  If present, the controller will locate the Machine
-and BareMetalHost host objects via their annotations, and (in serial) use the
-BareMetalHost API to power off the machine, delete the Node, and then power the
-machine back on again.
+This proposal calls for a new machine remediation controller (MRC) in CAPBM
+which watches for the presence of a `host.metal3.io/external-remediation` Machine
+annotation. If present, the controller will locate the Machine
+and BareMetalHost host objects via their annotations, and will annotate the BareMetalHost
+CR with a `reboot.metal3.io/machine-remediation`. Upon host power off, the controller
+will delete the node and then remove the annotation, to power on the host by
+utilizing [Baremetal-Operator reboot API](https://github.com/metal3-io/metal3-docs/blob/master/design/reboot-interface.md).
 
-In order to track the state of the recovery workflow, a [new
-CRD](https://github.com/kubevirt/machine-remediation/blob/master/pkg/apis/machineremediation/v1alpha1/machineremediation_types.go)
-is proposed.
+After restart/crash of the new controller it will check for
+`reboot.metal3.io/machine-remediation` annotation on all hosts,
+and continue remediation process, to make sure that such host is
+not left in powered off state.
+
+## Assumptions
+
+MHC checks that each machine has a node, and if it doesn't after some timeout,
+it will mark the machine as unhealthy. There could be situations where this timeout
+expires few seconds after MRC powered on the machine, resulting in one or more
+redundant reboot(s).
+Current MHC implementation checks that `now() - Machine.LastUpdated < timeout`.
+MRC deletes the unhealthy node, which updates `Machine.LastUpdated`.
+We assume that this implementation won't change.
+
+In addition, MRC has some operations to perform between node deletion (which triggers
+update of `Machine.LastUpdated`) to powering on the host, and these operations
+are also counted against that timeout. These operations are removing
+MAO's annotation and removing the reboot annotation. We assume that this
+time is negligible, especially compared to a newly provisioned host, and in case of
+temporary failure to remove one of the annotations we will risk in additional reboot.
 
 ### User Stories
 
 #### Story 1
 
-As a HA component of Metal³ that has identified a failed node, I would like a
-declarative way to have the Node stopped; deleted; and restarted, so that I can
-recover exclusive workloads and restore cluster capacity.
+As a customer I only care about my apps availability so I want my cluster
+infrastructure to be self healing and the nodes to be remediated automatically,
+without risking in any data loss/corruption.
 
 ### Implementation Details/Notes/Constraints [optional]
 
-The controller includes logic for power cycling a node.  
+The MRC will be implemented in openshift/CAPBM and will later need to be ported
+back to metal3/CAPBM.
 
-As rebooting (software) and power cycling (hardware) a machine is a long
-running multi-step process, there are currently discussions around the creation
-of a public mechanism for requesting initiating these processes atomically.
-
-While it is likely that the work proposed here may make use of such
-functionality once it exists, it should not be considered a pre-requisite for
-the purposes of evaluating this proposal.
+The controller includes logic for power cycling a host. Previous design relied
+on the existence of a new CRD to store state. This design is CRD-free and only
+uses annotations.
 
 ### Risks and Mitigations
 
@@ -131,29 +148,36 @@ RBAC rules will be needed to ensure that only specific roles can trigger
 machines to reboot. Without this, the system would be exposed to DoS style
 attacks.
 
+There's a possibility that the unhealthy node is running the MRC/MAO/BMO pod, which
+might lead to unexpected behaviours such as MHC not able to annotate the machine,
+or BMO not able to control the power of the host, or even MRC could delete itself.
+To mitigate this we need a multiple copies with a lock for each component involved.
+
 ## Design Details
 
-See [PoC code](https://github.com/kubevirt/machine-remediation/)
-
-- A new [Machine Remediation CRD](https://github.com/kubevirt/machine-remediation/blob/master/pkg/apis/machineremediation/v1alpha1/machineremediation_types.go)
-- Two new controllers:
-  - [node reboot](https://github.com/kubevirt/machine-remediation/tree/master/pkg/controllers/nodereboot) which looks for the annoation and creates Machine Remediation CRs
-  - [machine remediation](https://github.com/kubevirt/machine-remediation/tree/master/pkg/controllers/machineremediation) which reboots the machine and deletes the Node object (which also erases the signalling annotation)
-- A new annotation (namespace and name is open for discussion)
+MRC will:
+1. Power off hosts referenced by unhealthy Machine (by adding
+`reboot.metal3.io/machine-remediation` annotation)
+2. Delete nodes referenced by unhealthy Machines (when referenced host is powered off)
+3. Remove `host.metal3.io/external-remediation` annotation from powered off
+hosts referenced by node-less machines
+5. Power on hosts referenced by machines without
+`host.metal3.io/external-remediation` annotation (by removing
+`reboot.metal3.io/machine-remediation` annotation from host)
 
 ### Work Items
 
-- Make any requested modifications
-- Create a PR from  https://github.com/kubevirt/machine-remediation/ into https://github.com/metal3-io/cluster-api-provider-baremetal
+- Create a new machine remediation controller in CAPBM repo
 
 ### Dependencies
 
 This design is intended to integrate with OpenShift’s [Machine Healthcheck
 implementation](https://github.com/openshift/machine-api-operator/blob/master/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go#L407)
+ and [Baremetal Operator Reboot API](https://github.com/metal3-io/baremetal-operator/pull/424)
 
 ### Test Plan
 
-Unit tests are included in the code-base.
+Unit tests will be added for the new controller.
 
 In addition we will develop end-to-end test plans that cover both transient and
 permanent failures, as well as negative-flow tests where the IPMI in
@@ -166,8 +190,13 @@ No changes are required to preserve the existing behaviour.
 
 ### Version Skew Strategy
 
-By shipping the new controller with the baremetal-operator that it consumes, we
-can prevent any version mismatches.
+If CAPBM will be downgraded and BMO version will include the reboot functionality,
+we might end with a powered off host. This can happen if remediation process started,
+MRC requested for a power off by adding suffixed reboot annotation, and then CAPBM
+being downgraded to a version without MRC. There will be no one to remove that annotation
+and BMO will keep the host in powered off state until annotation removal.
+This will be solved as soon as the version skew is gone and they both use either
+reboot-supported versions or not at all.
 
 ## Drawbacks [optional]
 
@@ -177,11 +206,14 @@ any implementation is necessarily non-standard.
 If other platforms come to see value in power based recovery, there may need to
 design a different or more formal signaling method (than an annotation) as well
 as decompose the implementation into discrete units that can live behind a
-platform independant interface such as the Machine or Cluster APIs.
+platform independent interface such as the Machine or Cluster APIs.
 
 ## Alternatives [optional]
 
-Wait for equivalent functionality to be exposed by the Machine and/or Cluster APIs.
+1. Wait for equivalent functionality to be exposed by the Machine and/or Cluster APIs.
+2. Use CRD and a new operator for machine remediation, this was tried in the past but
+was mainly rejected since there was no operator to install the CRD of the new machine
+remediation operator.
 
 ## References
 

--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -136,7 +136,7 @@ without risking in any data loss/corruption.
 ### Implementation Details/Notes/Constraints [optional]
 
 The MRC will be implemented in openshift/CAPBM and will later need to be ported
-back to metal3/CAPBM.
+back to metal3/CAPM3.
 
 Previous design relied on the existence of a new CRD to store state.
 This design is CRD-free and only uses annotations.

--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -129,8 +129,8 @@ temporary failure to remove one of the annotations we will risk in additional re
 
 #### Story 1
 
-As a customer I only care about my apps availability so I want my cluster
-infrastructure to be self healing and the nodes to be remediated automatically,
+As a customer, I would like to have highly available applications so that my
+cluster infrastructure will be self healing and the nodes to be remediated automatically,
 without risking in any data loss/corruption.
 
 ### Implementation Details/Notes/Constraints [optional]

--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -205,16 +205,17 @@ No changes are required to preserve the existing behaviour.
 
 ### Version Skew Strategy
 
-CAPBM and BMO are delivered via the same image (both are installed by MAO, but running
-in a different pod), therefore an upgrade or downgrade affecting one component will
+If CAPM3 and the BMO are in different pods, an upgrade or downgrade could lead to
+version skew (one pod supports machine remediation and the other doesn't)
+An upgrade or downgrade affecting one component will
 eventually be applied to the other and any version skew is temporary.
-During the transient case that CAPBM does not include the MRC, Host can be left in powered
+During the transient case that CAPM3 does not include the MRC, Host can be left in powered
 off state, since MRC could add reboot annotation, and then it get downgraded, and there will
 be no controller to remove the reboot annotation.
 During the transient case that BMO does not support the reboot API, MRC could request for a reboot,
 which won't commence until BMO upgrades to a version which supports reboot annotation.
 In both cases, the impact is just delayed remediation and will be resolved once there's
-no version skew. 
+no version skew.
 
 ## Drawbacks [optional]
 

--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -138,9 +138,8 @@ without risking in any data loss/corruption.
 The MRC will be implemented in openshift/CAPBM and will later need to be ported
 back to metal3/CAPBM.
 
-The controller includes logic for power cycling a host. Previous design relied
-on the existence of a new CRD to store state. This design is CRD-free and only
-uses annotations.
+Previous design relied on the existence of a new CRD to store state.
+This design is CRD-free and only uses annotations.
 
 ### Risks and Mitigations
 

--- a/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -206,9 +206,9 @@ platform independent interface such as the Machine or Cluster APIs.
 ## Alternatives [optional]
 
 1. Wait for equivalent functionality to be exposed by the Machine and/or Cluster APIs.
-2. Use CRD and a new operator for machine remediation, this was tried in the past but
-was mainly rejected since there was no operator to install the CRD of the new machine
-remediation operator.
+2. Use a CRD to track the remediation progress instead of inferring it based on the existence or
+otherwise of Node objects, Machine and Host annotations. This was tried in the past but was mainly
+rejected since there was no operator to install that CRD.
 
 ## References
 


### PR DESCRIPTION
Previous design was using new CRD, this one doesn't rely on CRD and utilizes BMO reboot api