### PR TITLE
template: move design details section before implementation details

### DIFF
--- a/design/_template.md
+++ b/design/_template.md
@@ -118,6 +118,13 @@ feel real for users without getting bogged down.
 
 #### Story 2
 
+## Design Details
+
+- What will actually need to change in the code?
+- What new objects is this going to require?
+- What new fields are needed, for either the Spec or Status section?
+- What other changes (labels, annotations, etc.) are needed?
+
 ### Implementation Details/Notes/Constraints
 
 - What are the caveats to the implementation?
@@ -130,13 +137,6 @@ feel real for users without getting bogged down.
 What are the risks of this proposal and how do we mitigate.  Think
 broadly.  For example, consider both security and how this will impact
 the larger kubernetes ecosystem.
-
-## Design Details
-
-- What will actually need to change in the code?
-- What new objects is this going to require?
-- What new fields are needed, for either the Spec or Status section?
-- What other changes (labels, annotations, etc.) are needed?
 
 ### Work Items
 


### PR DESCRIPTION
It has been bothering me that we talk about implementation details
before design details. I think that was a mistake in importing the
original version of the template, so let's switch the order of those
sections.