### PR TITLE
add zaneb and maelk as approvers for this repository

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,5 +3,6 @@
 approvers:
  - dhellmann
  - hardys
+ - maelk
  - russellb
  - zaneb

--- a/OWNERS
+++ b/OWNERS
@@ -4,3 +4,4 @@ approvers:
  - dhellmann
  - hardys
  - russellb
+ - zaneb


### PR DESCRIPTION
Following the process in
https://github.com/metal3-io/metal3-docs/tree/master/maintainers I have
consulted with @russellb and @hardys about adding both @zaneb and @maelk
to the approvers list for this repository.