### PR TITLE
Change Metal3 community meeting link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Kubernetes interfaces.
 * [Metal³ Development Mailing List](https://groups.google.com/forum/#!forum/metal3-dev)
 * [#cluster-api-baremetal](https://kubernetes.slack.com/messages/CHD49TLE7)
   on Kubernetes Slack
-* Bi-Weekly Community Meetings every alternate Wednesday at 14:00 UTC
-  on [Zoom](https://zoom.us/j/618270818)
+* Bi-Weekly Community Meetings every alternate Wednesday at 13:00 UTC
+  on [Microsoft Teams](https://teams.microsoft.com/l/meetup-join/19%3ameeting_Nzg3MzQwMjUtOTI1Yi00ZTNhLWI3ZDktZmRkNTQ4NDgxY2E1%40thread.v2/0?context=%7b%22Tid%22%3a%22d2585e63-66b9-44b6-a76e-4f4b217d97fd%22%2c%22Oid%22%3a%22456f342b-7f3c-4825-abcd-e095f00cd654%22%7d)
 * Previous meetings: \[ [notes][notes] | [recordings][recordings] \]
 
 ## More Documentation
@@ -25,4 +25,4 @@ Kubernetes interfaces.
 For more documentation, please see <http://metal3.io/documentation.html>
 
 [notes]: https://docs.google.com/document/d/1d7jqIgmKHvOdcEmE2v72WDZo9kz7WwhuslDOili25Ls/edit
-[recordings]: https://www.youtube.com/playlist?list=PL3piInrK5Z0fKv7dwBU71Mn58LngdqOKA
+[recordings]: https://www.youtube.com/playlist?list=PL2h5ikWC8viJY4SNeOpCKTyERToTbJJJA


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR changes Metal3 community meeting link from Zoom to Microsoft Teams, recordings link, and time of the meeting accordingly.