### PR TITLE
Update bare-metal style guide

### DIFF
--- a/design/bare-metal-style-guide.md
+++ b/design/bare-metal-style-guide.md
@@ -9,21 +9,28 @@ depends!
 The goal of this document is to resolve this question and make it easy
 for anyone to follow the agreed convention.
 
-## 1. In prose, it is "bare metal"
+## 1. In prose, as a noun, it is "bare metal"
 
 Examples:
 
-1. "We are implementing bare metal host management for Kubernetes"
-1. "We manage bare metal hosts"
+"Some workloads only ever run on bare metal"
+"We need to ensure consistency between bare metal and other platforms"
 
-## 2. For names, it is "Bare Metal"
+## 2. In prose, as an adjective, it is "bare-metal"
+
+Examples:
+
+"We are implementing bare-metal host management for Kubernetes"
+"We manage bare-metal hosts"
+
+## 3. For names, it is "Bare Metal"
 
 Examples:
 
 1. "The Bare Metal Operator"
 1. "The Bare Metal Actuator"
 
-## 3. For lower-cased technical names, it is "baremetal"
+## 4. For lower-cased technical names, it is "baremetal"
 
 Examples:
 
@@ -31,10 +38,8 @@ Examples:
 1. "The Bare Metal Actuator is in the cluster-api-provider-baremetal repo"
 1. "The 'baremetal' driver implements support for bare metal servers"
 
-## 4. For camel-cased identifiers in code, it is "BareMetal"
+## 5. For camel-cased identifiers in code, it is "BareMetal"
 
 Examples:
 
 1. "The BareMetalHost resource"
-
-## 5. It is never "bare-metal"


### PR DESCRIPTION
This update is in response to discussion on the following review from
OpenShift where this style guide was referenced:

https://github.com/openshift/enhancements/pull/331

Dan Winship pointed out that it is proper to use "bare-metal" in
prose when it is used as an adjective.