### PR TITLE
Update community meeting and other reference links

### DIFF
--- a/design/baremetal-operator/how-ironic-works.md
+++ b/design/baremetal-operator/how-ironic-works.md
@@ -361,7 +361,7 @@ Starting with the bare metal node in the "available" provision_state:
    disk image.
 
 5. Monitor the provisioning operation by [fetching the machine
-   state](how-do-i-identify-the-current-state) periodically, looking
+   state](#how-do-i-identify-the-current-state) periodically, looking
    for it to be set to `active`.
 
    The "provision_state" field will track the state of the node along

--- a/design/community/cncf-sandbox-application.adoc
+++ b/design/community/cncf-sandbox-application.adoc
@@ -49,11 +49,12 @@ GitHub issues on each repository.
 *Initial committers*:
 
 Initial committers are reflected in the OWNERS file from each repository.  For example:
-* https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/OWNERS
-* https://github.com/metal3-io/baremetal-operator/blob/master/OWNERS
 
-The process for adding/removing committers (or maintainers) is:
-https://github.com/metal3-io/metal3-docs/tree/master/maintainers
+* link:https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/OWNERS[cluster-api-provider-metal3 repository owners file]
+* link:https://github.com/metal3-io/baremetal-operator/blob/master/OWNERS[baremetal-operator repository owners file]
+
+The process for adding/removing committers (or maintainers) is
+link:https://github.com/metal3-io/metal3-docs/tree/master/maintainers[here].
 
 There are currently maintainers across different repositories from the following
 companies:
@@ -90,15 +91,14 @@ As of 2020-03-25:
 * Web page (https://metal3.io) hosted on GitHub pages:
   https://github.com/metal3-io/metal3-io.github.io
 * Infrastructure resources: https://github.com/metal3-io/project-infra/
-* https://metal3.io/community-resources.html
+* Community resources: https://metal3.io/community-resources.html
 
 *Communication*:
 
 * link:https://groups.google.com/forum/#!forum/metal3-dev[Mailing List]
 * Slack Channel: #cluster-api-baremetal on the Kubernetes Slack
 * link:https://docs.google.com/document/d/1d7jqIgmKHvOdcEmE2v72WDZo9kz7WwhuslDOili25Ls/edit[Metal3 community meetings notes]
-* link:https://teams.microsoft.com/l/meetup-join/19%3ameeting_Nzg3MzQwMjUtOTI1Yi00ZTNhLWI3ZDktZmRkNTQ4NDgxY2E1%40thread.v2/0?context=%7b%22Tid%22%3a%22d2585e63-66b9-44b6-a76e-4f4b217d97fd%22%2c%22Oid%22%3a%22456f342b-7f3c-4825-abcd-e095f00cd654%22%7d
-[Bi-weekly Teams meeting]
+* link:https://teams.microsoft.com/l/meetup-join/19%3ameeting_Nzg3MzQwMjUtOTI1Yi00ZTNhLWI3ZDktZmRkNTQ4NDgxY2E1%40thread.v2/0?context=%7b%22Tid%22%3a%22d2585e63-66b9-44b6-a76e-4f4b217d97fd%22%2c%22Oid%22%3a%22456f342b-7f3c-4825-abcd-e095f00cd654%22%7d[Bi-weekly Teams meeting]
 
 *Social Media Accounts*:
 

--- a/design/community/foundation-proposal.md
+++ b/design/community/foundation-proposal.md
@@ -50,7 +50,7 @@ a next step of applying as a CNCF Sandbox project.
   proposal is only about the community future.
 - No changes to committer processes are proposed here.  We already have a
   documented [process for adding and removing
-  maintainers](../maintainers/README.md).
+  maintainers](../../maintainers/README.md).
 
 ## Proposal
 


### PR DESCRIPTION
This patch is a follow up to #130  that introduced a typo(blank space) in community meeting link and also updates non existing reference links in other documents.