### PR TITLE
Add list of OWNERS across all repositories

### DIFF
--- a/maintainers/ALL-OWNERS
+++ b/maintainers/ALL-OWNERS
@@ -1,0 +1,22 @@
+# All approvers from all top-level OWNERS files
+# See metal3-docs/maintainers/all-owners.sh
+
+approvers:
+- bfournie
+- codificat
+- derekhiggins
+- dhellmann
+- digambar15
+- dtantsur
+- fmuyassarov
+- hardys
+- imain
+- juliakreger
+- kashifest
+- knowncitizen
+- maelk
+- mhrivnak
+- ogelbukh
+- russellb
+- stbenjam
+- zaneb

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -82,7 +82,9 @@ The process to grant approval access to a candidate is as follows:
   the maintainer expectations documented here.
 
 - If the candidate agrees access is granted by adding the new maintainer to the
-  appropriate `OWNERS` file(s).
+  appropriate `OWNERS` file(s).  The `metal3-docs/maintainers/ALL-OWNERS` file
+  should be updated as well if this is the first time the person has been added
+  to a Metal3 project `OWNERS` file.
 
 ## Removing Approval Access Due to Inactivity
 

--- a/maintainers/all-owners.sh
+++ b/maintainers/all-owners.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+REPOS=" \
+  baremetal-operator \
+  base-image \
+  cluster-api-provider-metal3 \
+  hardware-classification-controller \
+  ip-address-manager \
+  ironic-client \
+  ironic-image \
+  ironic-hardware-inventory-recorder-image \
+  ironic-inspector-image \
+  ironic-ipa-downloader \
+  ironic-prometheus-exporter \
+  metal3-io.github.io \
+  metal3-dev-env \
+  metal3-docs \
+  metal3-helm-chart \
+  metal3-smart-exporter \
+  project-infra \
+  static-ip-manager-image \
+"
+
+all_owners_raw() {
+  for repo in $REPOS; do
+    if [ "$repo" = "metal3-io.github.io" ]; then
+      filter='.filters.".*".approvers'
+    else
+      filter='.approvers'
+    fi
+    curl -s "https://raw.githubusercontent.com/metal3-io/$repo/master/OWNERS" | \
+      yq -y $filter | \
+      grep -v "null" | \
+      grep -v "\.\.\."
+  done
+}
+
+echo "# All approvers from all top-level OWNERS files"
+echo "# See metal3-docs/maintainers/all-owners.sh"
+echo
+echo "approvers:"
+
+all_owners_raw | \
+  tr '[:upper:]' '[:lower:]' | \
+  sort -u


### PR DESCRIPTION
One of the CNCF onboarding tasks is to provide a single OWNERS file that
includes all maintainers from the project [1].  This PR includes a new
file to meet that requirement.  I've also included the script I used to
generate it.

[1] https://github.com/cncf/toc/issues/532