### PR TITLE
Add explicit reboot mode options

### DIFF
--- a/design/baremetal-operator/reboot-interface.md
+++ b/design/baremetal-operator/reboot-interface.md
@@ -138,6 +138,25 @@ The controller automatically removes all annotations with the
 
 - the Host is deprovisioned
 
+The annotation value should be a JSON map containing a key `'mode'` with values
+of `'hard'` or `'soft'` to specify the reboot mode. The default reboot mode is
+`'soft'`. These are a few examples of using the reboot API:
+
+- `reboot.metal.io` -- immediate reboot via soft shutdown first,
+  followed by a hard shutdown if the soft shutdown fails.
+- `reboot.metal3.io: {'mode':'hard'}` -- immediate reboot via hard
+  shutdown, potentially allowing for high-availability use-cases.
+- `reboot.metal3.io/{key}` -- phased reboot, issued and managed by the
+  client registered with the `key`, via soft shutdown first, followed
+  by a hard reboot if the soft reboot fails.
+- `reboot.metal3.io/{key}: {'mode':'hard'}` -- phased reboot, issued
+  and managed by the client registered with the `key`, via hard
+  shutdown.
+
+It's important to note that as the API supports multiple clients, a hard
+shutdown request takes priority over a soft shutdown request, allowing
+workload recovery to take precedence over a graceful shutdown of a node.
+
 ## Drawbacks
 
 This requires clients to be somewhat well-behaved - for example, only deleting


### PR DESCRIPTION
Currently the reboot-interface is not suitable for all circumstances due to the softPowerOff being enacted first, leading to a delay in the node being rebooted. The suggestion here is to make this more flexible and allow the operator to select whether they want to default to hard reboots instead.