### PR TITLE
add feruzjon muyassarov as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@
 
 approvers:
  - dhellmann
+ - fmuyassarov
  - hardys
  - maelk
  - russellb


### PR DESCRIPTION
After following the process described in our community documentation
[1], there were no objections to adding Feruzjon as an approver.

[1] https://github.com/metal3-io/metal3-docs/tree/master/maintainers

/cc @fmuyassarov @zaneb @hardys @russellb @maelk