### PR TITLE
Update the community meeting notes link to the new doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ come talk to us!
   channel
 * Join to the [Metal3-dev](https://groups.google.com/forum/#!forum/metal3-dev)
   google group for the edit access to the
-  [Community meetings Notes](https://groups.google.com/forum/#!forum/metal3-dev)
+  [Community meetings Notes](https://docs.google.com/document/d/1IkEIh-ffWY3DaNX3aFcAxGbttdEY_symo7WAGmzkWhU/edit)
 * Subscribe to the [Metal³ Development Mailing List](https://docs.google.com/document/d/1d7jqIgmKHvOdcEmE2v72WDZo9kz7WwhuslDOili25Ls/edit)
   for the project related anouncements, discussions and questions.
 * Come and meet us in our weekly community meetings on every
   Wednesday at 13:00 UTC on [Zoom](https://zoom.us/j/97255696401?pwd=ZlJMckNFLzdxMDNZN2xvTW5oa2lCZz09)
 * If you missed the previous community meeting, you can still find the notes
-  [here](https://docs.google.com/document/d/1d7jqIgmKHvOdcEmE2v72WDZo9kz7WwhuslDOili25Ls/edit)
+  [here](https://docs.google.com/document/d/1IkEIh-ffWY3DaNX3aFcAxGbttdEY_symo7WAGmzkWhU/edit)
   and recordings [here](https://www.youtube.com/playlist?list=PL2h5ikWC8viJY4SNeOpCKTyERToTbJJJA)
 
 ## Code of Conduct


### PR DESCRIPTION
We have created a new google document for keeping community
meeting notes. This patch updates the referenced links.
old doc: https://docs.google.com/document/d/1d7jqIgmKHvOdcEmE2v72WDZo9kz7WwhuslDOili25Ls/edit
new doc: https://docs.google.com/document/d/1IkEIh-ffWY3DaNX3aFcAxGbttdEY_symo7WAGmzkWhU/edit