### PR TITLE
Replace master branch reference with main

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ come talk to us!
 
 ## Code of Conduct
 
-See our [Code of Conduct](https://github.com/metal3-io/metal3-docs/blob/master/CODE_OF_CONDUCT.md)
+See our [Code of Conduct](https://github.com/metal3-io/metal3-docs/blob/main/CODE_OF_CONDUCT.md)

--- a/design/baremetal-operator/bmo-part-of-capm3.md
+++ b/design/baremetal-operator/bmo-part-of-capm3.md
@@ -206,9 +206,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: capm3-system
 resources:
-- github.com/metal3-io/baremetal-operator/deploy/operator/?ref=master
-- github.com/metal3-io/baremetal-operator/deploy/crds/?ref=master
-- github.com/metal3-io/baremetal-operator/deploy/rbac/?ref=master
+- github.com/metal3-io/baremetal-operator/deploy/operator/?ref=main
+- github.com/metal3-io/baremetal-operator/deploy/crds/?ref=main
+- github.com/metal3-io/baremetal-operator/deploy/rbac/?ref=main
 
 configMapGenerator:
 - behavior: create

--- a/design/baremetal-operator/detached-annotation.md
+++ b/design/baremetal-operator/detached-annotation.md
@@ -97,7 +97,7 @@ move directly to the `Deleting` state, without performing any `Deprovisioning`.
 ## Alternatives
 
 It would be possible to modify the behavior of the
-[pause annotation](https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#pausing-reconciliation)
+[pause annotation](https://github.com/metal3-io/baremetal-operator/blob/main/docs/api.md#pausing-reconciliation)
 such that Ironic hosts are removed while paused, however
 this means that we cannot reflect any error via the status
 or increment the errorCount for the retry backoff.

--- a/design/baremetal-operator/external-introspection.md
+++ b/design/baremetal-operator/external-introspection.md
@@ -33,7 +33,7 @@ more quickly, ref user stories below).
 
 ### Disable inspection proposal
 
-To align with the [inspection API proposal](https://github.com/metal3-io/metal3-docs/blob/master/design/baremetal-operator/inspection-api.md),
+To align with the [inspection API proposal](https://github.com/metal3-io/metal3-docs/blob/main/design/baremetal-operator/inspection-api.md),
 the `inspect.metal3.io` annotation will be reused, with the addition of a value.
 
 The optional `inspect.metal3.io: disabled` annotation will be used to describe
@@ -41,7 +41,7 @@ the situation where we wish to disable the default inspection behavior.
 
 When the BMO finds this annotation, it will skip performing inspection
 during the
-[Inspecting state](https://github.com/metal3-io/baremetal-operator/blob/master/docs/BaremetalHost_ProvisioningState.png)
+[Inspecting state](https://github.com/metal3-io/baremetal-operator/blob/main/docs/BaremetalHost_ProvisioningState.png)
 
 ### Hardware status update proposal
 
@@ -103,6 +103,6 @@ status fields.
 
 ## References
 
-- Inspection API [proposal](https://github.com/metal3-io/metal3-docs/blob/master/design/baremetal-operator/inspection-api.md)
+- Inspection API [proposal](https://github.com/metal3-io/metal3-docs/blob/main/design/baremetal-operator/inspection-api.md)
 - Live Image [proposal](https://github.com/metal3-io/metal3-docs/pull/150)
 - Live Image [implementation](https://github.com/metal3-io/baremetal-operator/pull/754)

--- a/design/baremetal-operator/implicit-boot-mode.md
+++ b/design/baremetal-operator/implicit-boot-mode.md
@@ -106,7 +106,7 @@ that is also easy to document.
 The proposal, therefore, is to always use BIOS mode when using IPMI
 and to prefer UEFI when using Redfish. We can implement this by adding
 a new method to the [AccessDetails
-interface](https://github.com/metal3-io/baremetal-operator/blob/master/pkg/bmc/access.go#L27)
+interface](https://github.com/metal3-io/baremetal-operator/blob/main/pkg/bmc/access.go#L27)
 to return the properties for a host, including the `boot_mode`. This
 API is consistent with other similar methods in that class that return
 other sets of data passed to Ironic when a host is registered.
@@ -141,7 +141,7 @@ values later for other hardware platforms.
 ## Design Details
 
 - Update the [AccessDetails
-  interface](https://github.com/metal3-io/baremetal-operator/blob/master/pkg/bmc/access.go#L27)
+  interface](https://github.com/metal3-io/baremetal-operator/blob/main/pkg/bmc/access.go#L27)
   to include the new method, `NodeProperties()`.
 - Update each implementation of the interface to include the new
   method with at least a static return value.

--- a/design/baremetal-operator/inspection-api.md
+++ b/design/baremetal-operator/inspection-api.md
@@ -19,7 +19,7 @@ including those changes need to be re-collected and updated on the spec of the
 corresponding BareMetalHost object without having to delete it.
 
 Implementation of this proposal is based on using annotation (similar to
-[Reboot API](https://github.com/metal3-io/metal3-docs/blob/master/design/baremetal-operator/reboot-interface.md))
+[Reboot API](https://github.com/metal3-io/metal3-docs/blob/main/design/baremetal-operator/reboot-interface.md))
 to request inspection of a `Ready` BareMetalHost.
 Once the annotation is set on BareMetalHost, the baremetal operator will
 request hardware inspection of the host from Ironic.
@@ -84,5 +84,5 @@ hardware details of the host.
 
 ## References
 
-- Reboot API [proposal](https://github.com/metal3-io/metal3-docs/blob/master/design/baremetal-operator/reboot-interface.md)
+- Reboot API [proposal](https://github.com/metal3-io/metal3-docs/blob/main/design/baremetal-operator/reboot-interface.md)
 - Reboot API [implementation](https://github.com/metal3-io/baremetal-operator/pull/424)

--- a/design/baremetal-operator/managing-provisioning-dependencies.md
+++ b/design/baremetal-operator/managing-provisioning-dependencies.md
@@ -14,7 +14,7 @@ in-progress
 ## Summary
 
 This document explains the implementation of the Baremetal Operator Pod
-as provisioned on any one of the masters in the cluster.
+as provisioned on any one of the controlplanes in the cluster.
 
 ## Motivation
 
@@ -54,9 +54,9 @@ specific location or from the internet.
 The requirement for a static IP stems from being able to run a DHCP/PXE
 server within the pod.  Using a dhcp assigned address on the provisioning
 network causes dnsmasq to error out.  At first I had thought of just
-assigning static IPs to each provisioning interface on each master node
+assigning static IPs to each provisioning interface on each controlplane node
 but this quickly becomes complicated to manage.  Especially in the event
-of a master going down and being reprovisioned, rebooted etc.
+of a controlplane going down and being reprovisioned, rebooted etc.
 
 The solution we came up with to resolve this is to use the 'lifetime'
 From the ip-address manpage:

--- a/design/baremetal-operator/reboot-interface.md
+++ b/design/baremetal-operator/reboot-interface.md
@@ -20,7 +20,7 @@ sequential changes to the spec).
 ## Motivation
 
 We require a non-destructive way to fence a Kubernetes node. Some nodes cannot
-be replaced (it is currently not possible for a new master to join a cluster),
+be replaced (it is currently not possible for a new controlplane to join a cluster),
 or are expensive to replace (e.g. if this would require rebalancing Ceph data).
 A solution to this is for fencing to reboot the Host, thus ensuring that
 running processes are stopped to avoid a split-brain scenario while still

--- a/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md
+++ b/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md
@@ -247,5 +247,5 @@ no version skew.
 
 1. [CAPI MachineHealthCheck](https://cluster-api.sigs.k8s.io/tasks/healthcheck.html)
 2. [CAPI External Remediation Proposal](https://github.com/kubernetes-sigs/cluster-api/pull/3190/files)
-3. [re-inspection API proposal](https://github.com/metal3-io/metal3-docs/blob/master/design/baremetal-operator/re-introspection-interface.md)
+3. [re-inspection API proposal](https://github.com/metal3-io/metal3-docs/blob/main/design/baremetal-operator/re-introspection-interface.md)
 4. [BareMetalHost v1alpha2 API Migration](https://github.com/metal3-io/metal3-docs/pull/101)

--- a/design/cluster-api-provider-metal3/node_reuse.md
+++ b/design/cluster-api-provider-metal3/node_reuse.md
@@ -55,7 +55,7 @@ on the label `infrastructure.cluster.x-k8s.io/node-reuse`).
 To achieve this, we need to
 
 1. be able to disable disk cleaning while deprovisioning.
-  This [feature](https://github.com/metal3-io/metal3-docs/blob/master/design/cluster-api-provider-metal3/allow_disabling_node_disk_cleaning.md)
+  This [feature](https://github.com/metal3-io/metal3-docs/blob/main/design/cluster-api-provider-metal3/allow_disabling_node_disk_cleaning.md)
   is implemented.
 
 2. be able reuse the same pool of hosts so that we get the storage
@@ -220,5 +220,5 @@ None
 
 ## References
 
-- Remediation proposal in Metal3: [Remediation](https://github.com/metal3-io/metal3-docs/blob/master/design/capm3-remediation-controller-proposal.md)
-- Disable disk cleaning proposal in Metal3: [Disable disk cleaning](https://github.com/metal3-io/metal3-docs/blob/master/design/cluster-api-provider-metal3/allow_disabling_node_disk_cleaning.md)
+- Remediation proposal in Metal3: [Remediation](https://github.com/metal3-io/metal3-docs/blob/main/design/capm3-remediation-controller-proposal.md)
+- Disable disk cleaning proposal in Metal3: [Disable disk cleaning](https://github.com/metal3-io/metal3-docs/blob/main/design/cluster-api-provider-metal3/allow_disabling_node_disk_cleaning.md)

--- a/design/community/cncf-sandbox-application.adoc
+++ b/design/community/cncf-sandbox-application.adoc
@@ -43,18 +43,18 @@ GitHub issues on each repository.
 
 *Release Methodology and Mechanics*:
 
-* link:https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/docs/releasing.md[cluster-api-provider-metal3] - Following the same release cadence as the cluster-api project of the Kubernetes cluster lifecycle SIG
+* link:https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/docs/releasing.md[cluster-api-provider-metal3] - Following the same release cadence as the cluster-api project of the Kubernetes cluster lifecycle SIG
 * baremetal-operator - No releases yet, link:https://github.com/metal3-io/metal3-docs/issues/71[issue for creating release process here].
 
 *Initial committers*:
 
 Initial committers are reflected in the OWNERS file from each repository.  For example:
 
-* link:https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/OWNERS[cluster-api-provider-metal3 repository owners file]
-* link:https://github.com/metal3-io/baremetal-operator/blob/master/OWNERS[baremetal-operator repository owners file]
+* link:https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/OWNERS[cluster-api-provider-metal3 repository owners file]
+* link:https://github.com/metal3-io/baremetal-operator/blob/main/OWNERS[baremetal-operator repository owners file]
 
 The process for adding/removing committers (or maintainers) is
-link:https://github.com/metal3-io/metal3-docs/tree/master/maintainers[here].
+link:https://github.com/metal3-io/metal3-docs/tree/main/maintainers[here].
 
 There are currently maintainers across different repositories from the following
 companies:
@@ -87,7 +87,7 @@ As of 2020-03-25:
   https://prow.apps.ci.metal3.io/
 * Jenkins server for some additional CI jobs using capacity from
   https://www.nordix.org/:
-  https://github.com/metal3-io/project-infra/blob/master/jenkins/README.md
+  https://github.com/metal3-io/project-infra/blob/main/jenkins/README.md
 * Web page (https://metal3.io) hosted on GitHub pages:
   https://github.com/metal3-io/metal3-io.github.io
 * Infrastructure resources: https://github.com/metal3-io/project-infra/
@@ -108,19 +108,19 @@ As of 2020-03-25:
 *Other References*:
 
 * link:https://www.youtube.com/watch?v=KIIkVD7gujY[Talk at KubeCon San Diego, Fall 2019]
-* link:https://github.com/metal3-io/metal3-docs/blob/master/design/community/foundation-proposal.md[Proposal to metal3-io community to apply to the CNCF Sandbox]
+* link:https://github.com/metal3-io/metal3-docs/blob/main/design/community/foundation-proposal.md[Proposal to metal3-io community to apply to the CNCF Sandbox]
 
 *Project Logo*:
 
-* link:https://github.com/metal3-io/metal3-docs/blob/master/images/metal3.svg[SVG]
-* link:https://github.com/metal3-io/metal3-docs/blob/master/images/metal3.png[PNG]
-* link:https://github.com/metal3-io/metal3-docs/blob/master/images/metal3-white.svg[SVG - White]
-* link:https://github.com/metal3-io/metal3-docs/blob/master/images/metal3-white.png[PNG - White]
-* link:https://github.com/metal3-io/metal3-docs/blob/master/images/metal3-.svg[SVG - Black]
-* link:https://github.com/metal3-io/metal3-docs/blob/master/images/metal3-black.png[PNG - Black]
-* link:https://github.com/metal3-io/metal3-docs/blob/master/images/metal3-website-sticker.svg[SVG - Sticker]
-* link:https://github.com/metal3-io/metal3-docs/blob/master/images/metal3-website-sticker.png[PNG - Sticker]
-* link:https://github.com/metal3-io/metal3-docs/blob/master/images/metal3-banner.pdf[PDF - Banner]
+* link:https://github.com/metal3-io/metal3-docs/blob/main/images/metal3.svg[SVG]
+* link:https://github.com/metal3-io/metal3-docs/blob/main/images/metal3.png[PNG]
+* link:https://github.com/metal3-io/metal3-docs/blob/main/images/metal3-white.svg[SVG - White]
+* link:https://github.com/metal3-io/metal3-docs/blob/main/images/metal3-white.png[PNG - White]
+* link:https://github.com/metal3-io/metal3-docs/blob/main/images/metal3-.svg[SVG - Black]
+* link:https://github.com/metal3-io/metal3-docs/blob/main/images/metal3-black.png[PNG - Black]
+* link:https://github.com/metal3-io/metal3-docs/blob/main/images/metal3-website-sticker.svg[SVG - Sticker]
+* link:https://github.com/metal3-io/metal3-docs/blob/main/images/metal3-website-sticker.png[PNG - Sticker]
+* link:https://github.com/metal3-io/metal3-docs/blob/main/images/metal3-banner.pdf[PDF - Banner]
 
 *External Dependencies*:
 

--- a/design/hardware-classification-controller/expected-hardware-configuration-validation.md
+++ b/design/hardware-classification-controller/expected-hardware-configuration-validation.md
@@ -44,7 +44,7 @@ into baremetal host.
 ### Implementation Details/Notes/Constraints
 
 Please refer to the [metal3 spec for
-bare-metal](https://github.com/metal3-io/baremetal-operator/blob/master/deploy/crds/metal3.io_baremetalhosts_crd.yaml).
+bare-metal](https://github.com/metal3-io/baremetal-operator/blob/main/deploy/crds/metal3.io_baremetalhosts_crd.yaml).
 
 - Below is sample yaml of Kind HardwareClassification.
 

--- a/design/ip-address-manager/ip-address-management-for-networkdata.md
+++ b/design/ip-address-manager/ip-address-management-for-networkdata.md
@@ -390,7 +390,7 @@ of the *IPAddress* objects.
 
 ### Dependencies
 
-[MetaData and NetworkData implementation](https://github.com/metal3-io/metal3-docs/blob/master/design/metadata-handling.md)
+[MetaData and NetworkData implementation](https://github.com/metal3-io/metal3-docs/blob/main/design/metadata-handling.md)
 
 ### Test Plan
 

--- a/design/ironic-debuggability-improvement.md
+++ b/design/ironic-debuggability-improvement.md
@@ -71,7 +71,7 @@ ironic-provisioning-log-watch.sh will be created in
 ironic-inspection-log-watch.sh will be created in
 <https://github.com/metal3-io/ironic-inspector-image>
 Both scripts will be added as new container entry points to
-<https://github.com/metal3-io/baremetal-operator/blob/master/ironic-deployment/ironic/ironic.yaml>
+<https://github.com/metal3-io/baremetal-operator/blob/main/ironic-deployment/ironic/ironic.yaml>
 
 ### Implementation Details/Notes/Constraints
 

--- a/design/ironic_authentication.md
+++ b/design/ironic_authentication.md
@@ -228,7 +228,7 @@ None
 ### Test Plan
 
 The secure setup will be deployed and tested as part of the metal3-dev-env
-integration tests ran for all PRs and daily from master.
+integration tests ran for all PRs and daily from main.
 
 ### Upgrade / Downgrade Strategy
 

--- a/design/reproducible-metal3-dev-env.md
+++ b/design/reproducible-metal3-dev-env.md
@@ -74,7 +74,7 @@ environments.
 * No changes to any of the metal3 components: the focus of this change is only
   on the development environment
 * Continue to pull metal3 dependencies themselves (BMO, CAPM3, etc.) from
-  master directly. Only external software outside of the main mandate of the
+  main directly. Only external software outside of the main mandate of the
   metal3 project is included in this proposal.
 
 ## Proposal

--- a/docs/presentations/metal3-overview/metal3-overview.html
+++ b/docs/presentations/metal3-overview/metal3-overview.html
@@ -20,7 +20,7 @@
 				     style="font-size:50%">
 					<section data-markdown
 					         data-separator-vertical="^\n\n\n"
-									 data-background-image="https://github.com/metal3-io/metal3-docs/raw/master/images/metal3.png"
+									 data-background-image="https://github.com/metal3-io/metal3-docs/raw/main/images/metal3.png"
 									 data-background-size="7%"
 									 data-background-position="top right 30%"
 									 data-background-opacity="0.4">
@@ -74,7 +74,7 @@
 
 <img data-src="metal3-integration-capi.png" height="70%" width="85%" />
 
-[If interested, here is a link for Relational Diagram for CRs](https://github.com/metal3-io/metal3-docs/blob/master/images/v1a2_crs.png)
+[If interested, here is a link for Relational Diagram for CRs](https://github.com/metal3-io/metal3-docs/blob/main/images/v1a2_crs.png)
 
 
 

--- a/maintainers/all-owners.sh
+++ b/maintainers/all-owners.sh
@@ -25,7 +25,7 @@ all_owners_raw() {
     else
       filter='.approvers'
     fi
-    curl -s "https://raw.githubusercontent.com/metal3-io/$repo/master/OWNERS" | \
+    curl -s "https://raw.githubusercontent.com/metal3-io/$repo/main/OWNERS" | \
       yq -y $filter | \
       grep -v "null" | \
       grep -v "\.\.\."


### PR DESCRIPTION
Metal3 docs default branch is switched to `main`. Also most other repos have already switched their default branch to `main`. This PR replaces appropriate mentions of `master` branch to `main`. 