### PR TITLE
move maelk to emeritus_approvers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,8 @@ approvers:
  - dtantsur
  - fmuyassarov
  - hardys
- - maelk
  - russellb
  - zaneb
+
+emeritus_approvers:
+ - maelk


### PR DESCRIPTION
Maël's focus has shifted from this project to other tasks thus the
OWNERS list has to be modified accordingly.