### PR TITLE
Fix mdbook quay image tag and bump mdBook version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MDBOOK_VERSION ?= 0.4.5
-MDBOOK_BIN_VERSION ?= v0.4.5
+MDBOOK_VERSION ?= latest
+MDBOOK_BIN_VERSION ?= v0.4.15
 SOURCE_PATH := docs/user-guide
 CONTAINER_RUNTIME ?= sudo docker
 IMAGE_NAME := quay.io/metal3-io/mdbook

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-MDBOOK_VERSION ?= latest
+MDBOOK_VERSION ?= 0.4.15
 MDBOOK_BIN_VERSION ?= v0.4.15
 SOURCE_PATH := docs/user-guide
 CONTAINER_RUNTIME ?= sudo docker
 IMAGE_NAME := quay.io/metal3-io/mdbook
+IMAGE_VERSION ?= latest
 HOST_PORT ?= 3000
 BIN_DIR := hack
 MDBOOK_BIN := $(BIN_DIR)/mdbook
@@ -30,14 +31,14 @@ netlify-build: $(MDBOOK_BIN) # Build the user guide
 .PHONY: container-image
 container-image: # Build mdbook local container image
 	$(CONTAINER_RUNTIME) build --build-arg MDBOOK_VERSION=$(MDBOOK_VERSION) \
-	./docs/ -t $(IMAGE_NAME):$(MDBOOK_VERSION)
+	./docs/ -t $(IMAGE_NAME):$(IMAGE_VERSION)
 
 .PHONY: build
 build: # Build the user guide
 	$(CONTAINER_RUNTIME) run \
 	--rm -it --name metal3 \
 	-v "$$(pwd):/workdir" \
-	$(IMAGE_NAME):$(MDBOOK_VERSION) \
+	$(IMAGE_NAME):$(IMAGE_VERSION) \
 	mdbook build $(SOURCE_PATH)
 
 .PHONY: serve
@@ -46,7 +47,7 @@ serve: # Serve the user-guide on localhost:3000 (by default)
 	--rm -it --init --name metal3 \
 	-v "$$(pwd):/workdir" \
 	-p $(HOST_PORT):3000 \
-	$(IMAGE_NAME):$(MDBOOK_VERSION) \
+	$(IMAGE_NAME):$(IMAGE_VERSION) \
 	mdbook serve --open $(SOURCE_PATH) -p 3000 -n 0.0.0.0
 
 .PHONY: clean
@@ -54,5 +55,5 @@ clean: # Clean mdbook generated content
 	$(CONTAINER_RUNTIME) run \
 	--rm -it --name metal3 \
 	-v "$$(pwd):/workdir" \
-	$(IMAGE_NAME):$(MDBOOK_VERSION) \
+	$(IMAGE_NAME):$(IMAGE_VERSION) \
 	mdbook clean $(SOURCE_PATH)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-MDBOOK_VERSION ?= 0.4.15
 MDBOOK_BIN_VERSION ?= v0.4.15
 SOURCE_PATH := docs/user-guide
 CONTAINER_RUNTIME ?= sudo docker
 IMAGE_NAME := quay.io/metal3-io/mdbook
-IMAGE_VERSION ?= latest
+IMAGE_TAG ?= latest
 HOST_PORT ?= 3000
 BIN_DIR := hack
 MDBOOK_BIN := $(BIN_DIR)/mdbook
@@ -28,17 +27,12 @@ netlify-build: $(MDBOOK_BIN) # Build the user guide
 ## Documentation tooling for local dev
 ## ------------------------------------
 
-.PHONY: container-image
-container-image: # Build mdbook local container image
-	$(CONTAINER_RUNTIME) build --build-arg MDBOOK_VERSION=$(MDBOOK_VERSION) \
-	./docs/ -t $(IMAGE_NAME):$(IMAGE_VERSION)
-
 .PHONY: build
 build: # Build the user guide
 	$(CONTAINER_RUNTIME) run \
 	--rm -it --name metal3 \
 	-v "$$(pwd):/workdir" \
-	$(IMAGE_NAME):$(IMAGE_VERSION) \
+	$(IMAGE_NAME):$(IMAGE_TAG) \
 	mdbook build $(SOURCE_PATH)
 
 .PHONY: serve
@@ -47,7 +41,7 @@ serve: # Serve the user-guide on localhost:3000 (by default)
 	--rm -it --init --name metal3 \
 	-v "$$(pwd):/workdir" \
 	-p $(HOST_PORT):3000 \
-	$(IMAGE_NAME):$(IMAGE_VERSION) \
+	$(IMAGE_NAME):$(IMAGE_TAG) \
 	mdbook serve --open $(SOURCE_PATH) -p 3000 -n 0.0.0.0
 
 .PHONY: clean
@@ -55,5 +49,5 @@ clean: # Clean mdbook generated content
 	$(CONTAINER_RUNTIME) run \
 	--rm -it --name metal3 \
 	-v "$$(pwd):/workdir" \
-	$(IMAGE_NAME):$(IMAGE_VERSION) \
+	$(IMAGE_NAME):$(IMAGE_TAG) \
 	mdbook clean $(SOURCE_PATH)

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1-slim
-ARG MDBOOK_VERSION="latest"
+ARG MDBOOK_VERSION="0.4.15"
 RUN cargo install mdbook --vers ${MDBOOK_VERSION}
 RUN cp /usr/local/cargo/bin/mdbook /usr/bin/mdbook
 WORKDIR /workdir

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1-slim
-ARG MDBOOK_VERSION="0.4.5"
+ARG MDBOOK_VERSION="latest"
 RUN cargo install mdbook --vers ${MDBOOK_VERSION}
 RUN cp /usr/local/cargo/bin/mdbook /usr/bin/mdbook
 WORKDIR /workdir

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1-slim
-ARG MDBOOK_VERSION="0.4.15"
-RUN cargo install mdbook --vers ${MDBOOK_VERSION}
+ARG MDBOOK_BIN_VERSION="0.4.15"
+RUN cargo install mdbook --vers ${MDBOOK_BIN_VERSION}
 RUN cp /usr/local/cargo/bin/mdbook /usr/bin/mdbook
 WORKDIR /workdir

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,12 +10,20 @@ Below is the concatenated file structure for the Metal³ user-guide.
 
 ```shell
 ├── book.toml
+├── README.md
 ├── src
-│   ├── images
-│   │   └── metal3-color.svg
-│   ├── introduction.md
-│   ├── project-overview.md
-│   └── SUMMARY.md
+│   ├── bmo
+│   │   └── OWNERS
+│   ├── capm3
+│   │   └── OWNERS
+│   ├── images
+│   │   └── metal3-color.svg
+│   ├── introduction.md
+│   ├── ipam
+│   │   └── OWNERS
+│   ├── ironic
+│   │   └── OWNERS
+│   └── SUMMARY.md
 └── theme
     └── favicon.svg
 ```
@@ -63,10 +71,4 @@ All the commands below are executed within mdbook container.
 
     ```bash
     $ make clean
-    ```
-
-1. Build mdbook container image locally.
-
-    ```bash
-    $ make container-image
     ```

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -43,8 +43,8 @@ Our Netlify configuration is in the [netlify.toml](https://github.com/metal3-io/
 All the configurations of the mdbook, such as content path, version, from where to get the binary while building the user-guide is defined in the [Makefile](https://github.com/metal3-io/metal3-docs/blob/main/Makefile).
 
 ```sh
-MDBOOK_VERSION ?= 0.4.5
-MDBOOK_BIN_VERSION ?= v0.4.5
+MDBOOK_VERSION ?= latest
+MDBOOK_BIN_VERSION ?= v0.4.15
 SOURCE_PATH := docs/user-guide
 CONTAINER_RUNTIME ?= sudo docker
 IMAGE_NAME := quay.io/metal3-io/mdbook

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -43,11 +43,11 @@ Our Netlify configuration is in the [netlify.toml](https://github.com/metal3-io/
 All the configurations of the mdbook, such as content path, version, from where to get the binary while building the user-guide is defined in the [Makefile](https://github.com/metal3-io/metal3-docs/blob/main/Makefile).
 
 ```sh
-MDBOOK_VERSION ?= latest
 MDBOOK_BIN_VERSION ?= v0.4.15
 SOURCE_PATH := docs/user-guide
 CONTAINER_RUNTIME ?= sudo docker
 IMAGE_NAME := quay.io/metal3-io/mdbook
+IMAGE_TAG ?= latest
 HOST_PORT ?= 3000
 BIN_DIR := hack
 MDBOOK_BIN := $(BIN_DIR)/mdbook


### PR DESCRIPTION
When running `make serve` to serve the user-guide on localhost:3000, it will complain with:

```
docker run \
--rm -it --init --name metal3 \
-v "$(pwd):/workdir" \
-p 3000:3000 \
quay.io/metal3-io/mdbook:0.4.5 \
mdbook serve --open docs/user-guide -p 3000 -n 0.0.0.0
Unable to find image 'quay.io/metal3-io/mdbook:0.4.5' locally
docker: Error response from daemon: manifest for quay.io/metal3-io/mdbook:0.4.5 not found: manifest unknown: manifest unknown.
See 'docker run --help'.
make: *** [Makefile:45: serve] Error 125
```
because there is no [quay image](https://quay.io/repository/metal3-io/mdbook?tab=tags) for mdbook with the tag v0.4.5. This PR changes it to use latest tag since that is the one which is available. 

Update: 

- It also bumps mdBook bin version from **v0.4.5** to latest **v0.4.15**
- renames instructions.md to README.md and updates the content
- removes unnecessary `$ make container-image` which just builds container images locally. Instead, anyone can use already built and pushed mdbook container image to quay.