### PR TITLE
🐛Fix all-owners.sh script and update list based on output

### DIFF
--- a/maintainers/ALL-OWNERS
+++ b/maintainers/ALL-OWNERS
@@ -3,22 +3,24 @@
 
 approvers:
 - andfasano
+- ashughorla
 - bfournie
 - derekhiggins
-- digambar15
 - dtantsur
 - elfosardo
-- furkatgofurov7
 - fmuyassarov
+- furkatgofurov7
 - hardys
 - hroyrh
+- imain
 - iurygregory
 - kashifest
 - knowncitizen
-- mhrivnak
 - ogelbukh
+- ravipwaghmare
 - russellb
 - stbenjam
+- xenwar
 - zaneb
 
 emeritus_approvers:

--- a/maintainers/all-owners.sh
+++ b/maintainers/all-owners.sh
@@ -25,8 +25,17 @@ all_owners_raw() {
     else
       filter='.approvers'
     fi
-    curl -s "https://raw.githubusercontent.com/metal3-io/$repo/main/OWNERS" | \
-      yq -y $filter | \
+    if [ "$repo" = "hardware-classification-controller" ] ||  [ "$repo" = "ironic-client" ] \
+      || [ "$repo" = "ironic-hardware-inventory-recorder-image" ] || [ "$repo" = "metal3-dev-env" ] \
+      || [ "$repo" = "metal3-helm-chart" ] || [ "$repo" = "static-ip-manager-image" ]; then
+      branch='master'
+    elif [ "$repo" = "metal3-io.github.io" ]; then
+      branch='source'
+    else
+      branch='main'
+    fi
+    curl -s "https://raw.githubusercontent.com/metal3-io/$repo/$branch/OWNERS" | \
+      yq $filter | \
       grep -v "null" | \
       grep -v "\.\.\."
   done

--- a/maintainers/all-owners.sh
+++ b/maintainers/all-owners.sh
@@ -35,7 +35,7 @@ all_owners_raw() {
       branch='main'
     fi
     curl -s "https://raw.githubusercontent.com/metal3-io/$repo/$branch/OWNERS" | \
-      yq $filter | \
+      yq -y $filter | \
       grep -v "null" | \
       grep -v "\.\.\."
   done

--- a/maintainers/all-owners.sh
+++ b/maintainers/all-owners.sh
@@ -25,14 +25,16 @@ all_owners_raw() {
     else
       filter='.approvers'
     fi
-    if [ "$repo" = "hardware-classification-controller" ] ||  [ "$repo" = "ironic-client" ] \
-      || [ "$repo" = "ironic-hardware-inventory-recorder-image" ] || [ "$repo" = "metal3-dev-env" ] \
-      || [ "$repo" = "metal3-helm-chart" ] || [ "$repo" = "static-ip-manager-image" ]; then
-      branch='master'
-    elif [ "$repo" = "metal3-io.github.io" ]; then
-      branch='source'
-    else
+    git ls-remote -q --exit-code --heads https://github.com/metal3-io/$repo main >/dev/null 2>&1
+    retVal=$?
+    if [ $retVal -eq 0 ]; then
       branch='main'
+    elif [ $retVal -ne 0 ]; then
+      if [ "$repo" = "metal3-io.github.io" ]; then
+        branch='source'
+      else
+        branch='master'
+      fi
     fi
     curl -s "https://raw.githubusercontent.com/metal3-io/$repo/$branch/OWNERS" | \
       yq -y $filter | \


### PR DESCRIPTION
This PR ~~fixes **yq** syntax error while running `all-owners.sh` and~~ introduces  `branch` var to differentiate repository branches, since we have still few repositories with the `master` branch as default, few transitioned to `main` and only _metal3-io.github.io_ is tracked using `source` branch as default. 
ALL-OWNERS file has been updated accordingly as per the script output. 

**Note:** I have gone through all repositories listed in the script and checked the maintainers with the one we have now auto-generated by script in the ALL-OWNERS file and it looks correct. Please let me know if the output is missing someone in the list. Thanks!