### PR TITLE
Include mariadb-image repo to the list of repos in all-owners.sh script

### DIFF
--- a/maintainers/all-owners.sh
+++ b/maintainers/all-owners.sh
@@ -10,6 +10,7 @@ REPOS=" \
   ironic-image \
   ironic-hardware-inventory-recorder-image \
   ironic-ipa-downloader \
+  mariadb-image \
   metal3-io.github.io \
   metal3-dev-env \
   metal3-docs \


### PR DESCRIPTION
As per https://github.com/metal3-io/metal3-docs/pull/250#issuecomment-1056964421 adding mariadb-image repo to complete the list of repos which is used to fetch all owners from that list.