### PR TITLE
User-guide: add user-guide URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ Kubernetes interfaces.
 * [Quick start](http://metal3.io/try-it.html)
 * [Demos](https://www.youtube.com/watch?v=VFbIHc3NbJo&list=PL2h5ikWC8viKmhbXHo1epPelGdCkVlF16&ab_channel=Metal3)
 * [Blog posts](https://metal3.io/blog/index.html)
-* [FAQ](https://metal3.io/blog/index.html)
+
+## Documentation
+
+Please see our [user-guide](https://metal3io.netlify.app/) to familiarize yourself with Metal³ and its features. We are currently in the process of writing
+the user-guide. As such, not all the topics might be covered yet.
 
 ## Community
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -30,7 +30,7 @@ The final content is built on the fly by Netlify as such, we don't store it on G
 
 ## What's the URL of the current user-guide
 
-[https://metal3-user-guide.netlify.app/](https://metal3-user-guide.netlify.app/)
+[https://metal3io.netlify.app/](https://metal3io.netlify.app/)
 
 ## How to check book content when reviewing a GitHub patch
 


### PR DESCRIPTION
Although the URL is not the best https://metal3io.netlify.app/, add it for now rather than hiding the content while it is be being added, because it can already benefit some users. I'm checking with CNCF and @russellb to have an alias to redirect the content to https://book.metal3.io.
