### PR TITLE
📖 Update release version notes in user guide

### DIFF
--- a/docs/user-guide/src/capm3/installation_guide.md
+++ b/docs/user-guide/src/capm3/installation_guide.md
@@ -16,16 +16,16 @@ install them yourself.
 1. Install Cluster API core compoenents i.e., core, bootstrap and control-plane providers. This will also install cert-manager, if it is not already installed.
 
     ```bash
-     clusterctl init --core cluster-api:v1.1.3 --bootstrap kubeadm:v1.1.3 \
-     --control-plane kubeadm:v1.1.3 -v5
+     clusterctl init --core cluster-api:v1.1.4 --bootstrap kubeadm:v1.1.4 \
+     --control-plane kubeadm:v1.1.4 -v5
     ```
 
 ## With clusterctl
 
-This method is recommended. You can specify the CAPM3 version you want to install by appending a version tag, e.g. `:v1.1.0`. If the version is not specified, the latest version available will be installed.
+This method is recommended. You can specify the CAPM3 version you want to install by appending a version tag, e.g. `:v1.1.2`. If the version is not specified, the latest version available will be installed.
 
 ```bash
-clusterctl init --infrastructure metal3:v1.1.0
+clusterctl init --infrastructure metal3:v1.1.2
 ```
 
 ## With kustomize
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       # Change the value of image/tag to your desired image URL or version tag
-      - image: quay.io/metal3-io/cluster-api-provider-metal3:v1.1.0
+      - image: quay.io/metal3-io/cluster-api-provider-metal3:v1.1.2
         name: manager
 ```
 

--- a/docs/user-guide/src/version_support.md
+++ b/docs/user-guide/src/version_support.md
@@ -13,17 +13,18 @@ IPAM releases are as follows:
 
 - CAPM3
     - v1beta1
-        - v1.1.1, v1.1.0
+        - v1.1.2, v1.1.1, v1.1.0
     - v1alpha5
         - v0.5.5, v0.5.4, v0.5.3, v0.5.2, v0.5.1, v0.5.0
 - IPAM
     - v1alpha1
-        - v1.1.2, v1.1.1, v1.1.0, v0.1.2, v0.1.1, v0.1.0
+        - v1.1.3, v1.1.2, v1.1.1, v1.1.0, v0.1.2, v0.1.1, v0.1.0
 
 The compatability of IPAM and CAPM3 API versions with CAPI is discussed [here](https://github.com/metal3-io/ip-address-manager#compatibility-with-cluster-api).
 
 Since BMO and Ironic do not follow similar release cycles they are backward compatible. However, we always tag the BMO and Ironic code base whenever we do a release in CAPM3. The tags have a prefix **capm3-** and the suffix is always the corresponding capm3- release version. So for example if we cut a `v1.0.0` release for CAPM3 we create a tag in the BMO and Ironic code base with `capm3-v1.0.0`. Following the same trend, the following tags for BMO and Ironic are available and supported (image tags):
 
+- capm3-v1.1.2
 - capm3-v1.1.1
 - capm3-v1.1.0
 - capm3-v0.5.5
@@ -37,10 +38,10 @@ Since BMO and Ironic do not follow similar release cycles they are backward comp
 
 Supported container images for BMO and Ironic can be found in quay. Examples are:
 
-- quay.io/metal3-io/ironic:capm3-v1.1.1
-- quay.io/metal3-io/baremetal-operator:capm3-v1.1.1
+- quay.io/metal3-io/ironic:capm3-v1.1.2
+- quay.io/metal3-io/baremetal-operator:capm3-v1.1.2
 
 Supported container images for CAPM3 and IPAM will always follow the supported release version tags. Examples are:
 
-- quay.io/metal3-io/cluster-api-provider-metal3:v1.1.1
-- quay.io/metal3-io/ip-address-manager:v1.1.2
+- quay.io/metal3-io/cluster-api-provider-metal3:v1.1.2
+- quay.io/metal3-io/ip-address-manager:v1.1.3


### PR DESCRIPTION
IPAM v1.1.3, CAPM3 v1.1.2 is out and CAPI has been uplifted to v1.1.4. 
capm3-v1.1.2 bmo & ironic images are available in quay.