### PR TITLE
Add separate OWNERS file for design docs

### DIFF
--- a/design/OWNERS
+++ b/design/OWNERS
@@ -1,0 +1,18 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+ - andfasano
+ - dtantsur
+ - russellb
+ - zaneb
+
+reviewers:
+ - furkatgofurov7
+
+emeritus_approvers:
+ - maelk
+ - hardys
+ - fmuyassarov
+
+options:
+  no_parent_owners: true


### PR DESCRIPTION
The approvers list for design docs is intentionally kept quite small, but we would like the freedom to add many more reviewers and approvers for documentation in general. By adding this OWNERS file with the no_parent_owners option set, we disconnect the design docs directory from the rest of the repo.