### PR TITLE
Update unified OWNERS file for user-guide patches

### DIFF
--- a/docs/user-guide/src/OWNERS
+++ b/docs/user-guide/src/OWNERS
@@ -7,21 +7,28 @@ approvers:
  - dtantsur
  - elfosardo
  - furkatgofurov7
+ - honza
  - iurygregory
  - kashifest
- - russellb
- - Xenwar
  - zaneb
  
 reviewers:
+ - adilGhaffarDev
  - ardaguclu
  - dukov
- - honza
- - macaptain
- - namnx228
+ - lentzi90
+ - mboukhalfa
+ - Rozzii
  - smoshiur1237
  - s3rj1k
+ - zhouhao3
 
 emeritus_approvers:
- - hardys
  - fmuyassarov
+ - hardys
+ - russellb
+ - Xenwar
+
+emeritus_reviewers:
+ - macaptain
+ - namnx228


### PR DESCRIPTION
Updates unified OWNERS for user-guide patch reviews with respect to reviewer or approval rights in [BMO](https://github.com/metal3-io/baremetal-operator/blob/main/OWNERS), [CAPM3](https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/OWNERS), [IPAM](https://github.com/metal3-io/ip-address-manager/blob/main/OWNERS) and [ironic-image](https://github.com/metal3-io/ironic-image/blob/main/OWNERS) repositories of Metal3 GitHub organization. 
Also moves some folks to emeritus_approvers/reviewers list: /cc @russellb @Xenwar @namnx228 @macaptain 

/cc @zaneb @dtantsur @honza @andfasano @kashifest @elfosardo 