### PR TITLE
Add build arg options section for custom source build of ironic-image

### DIFF
--- a/docs/user-guide/src/ironic/ironic-container-images.md
+++ b/docs/user-guide/src/ironic/ironic-container-images.md
@@ -39,6 +39,26 @@ triggers the build from source code:
 docker build . -f Dockerfile --build-arg INSTALL_TYPE=source
 ```
 
+When building the ironic image from source, it is also possible to specify a
+different source for ironic, ironic-inspector or the sushy library using the
+build arguments **IRONIC_SOURCE**, **IRONIC_INSPECTOR_SOURCE**,
+and **SUSHY_SOURCE**.
+The accepted formats are gerrit refs, like _refs/changes/89/860689/2_, commit
+hashes, like _a1fe6cb41e6f0a1ed0a43ba5e17745714f206f1f_, or a local directory
+that needs to be under the sources/ directory in the container context.
+
+An example of a full command installing ironic from a gerrit patch is:
+
+```bash
+docker build . -f Dockerfile --build-arg INSTALL_TYPE=source --build-arg IRONIC_SOURCE="refs/changes/89/860689/2"
+```
+
+An example using the local directory _sources/ironic_:
+
+```bash
+docker build . -f Dockerfile --build-arg INSTALL_TYPE=source --build-arg IRONIC_SOURCE="ironic"
+```
+
 ## Work with patches in the ironic-image
 
 The ironic-image allows testing patches for ironic projects building the


### PR DESCRIPTION
Source build can be customized using remote source like gerrit refs or commit hashes, or local source in a directory in the container context.