### PR TITLE
markdown: pin mdl to 0.12.0 and fix complaints

### DIFF
--- a/design/baremetal-operator/detached-annotation.md
+++ b/design/baremetal-operator/detached-annotation.md
@@ -109,4 +109,3 @@ and there are concerns about corner-cases such as adoption when an
 ephemeral Ironic is used and a rechedule occurs.
 
 ## References
-

--- a/design/ironic_authentication.md
+++ b/design/ironic_authentication.md
@@ -327,4 +327,3 @@ ironic is set up on the target cluster.
 
 * [ironic issue](https://github.com/metal3-io/metal3-docs/issues/92)
 * [Ironic and WSGI](https://docs.openstack.org/ironic/pike/install/include/configure-ironic-api-mod_wsgi.html)
-

--- a/docs/user-guide/src/capm3/pivoting.md
+++ b/docs/user-guide/src/capm3/pivoting.md
@@ -169,4 +169,3 @@ This can now be achieved with the following procedure:
     ```
 
 9. Delete the bootstrap cluster
-

--- a/docs/user-guide/src/flake/nordix_timeout.md
+++ b/docs/user-guide/src/flake/nordix_timeout.md
@@ -14,7 +14,5 @@ reading manifest latest in registry.nordix.org/quay-io-proxy/metal3-io/vbmc: rec
 - 29.06.2022: [metal3_main_v1b1_e2e_test_centos](https://artifactory.nordix.org/ui/native/metal3/jenkins-logs/registry-timeout-metal3_main_v1b1_e2e_test_centos-213.tgz)
 
 - 28.06.2022:
-  - [metal3_main_v1b1_integration_test_centos](https://artifactory.nordix.org/artifactory/metal3/jenkins-logs/registry-timeout-metal3_main_v1b1_integration_test_centos-190.tgz)
-  - [metal3_main_v1a5_integration_test_centos](https://artifactory.nordix.org/artifactory/metal3/jenkins-logs/registry-timeout-metal3_main_v1a5_integration_test_centos-167.tgz)
-
-
+   - [metal3_main_v1b1_integration_test_centos](https://artifactory.nordix.org/artifactory/metal3/jenkins-logs/registry-timeout-metal3_main_v1b1_integration_test_centos-190.tgz)
+   - [metal3_main_v1a5_integration_test_centos](https://artifactory.nordix.org/artifactory/metal3/jenkins-logs/registry-timeout-metal3_main_v1a5_integration_test_centos-167.tgz)

--- a/docs/user-guide/src/security_policy.md
+++ b/docs/user-guide/src/security_policy.md
@@ -124,4 +124,3 @@ public repo's review process as soon as possible and merge it.
 | Adam Rozman       | Rozzii              | Ericsson Software Technology   |
 
 **Please don't report any security vulnerability to the committee members directly.**
-

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -18,7 +18,7 @@ else
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
     --workdir /workdir \
-    registry.hub.docker.com/pipelinecomponents/markdownlint:latest \
+    registry.hub.docker.com/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2 \
     /workdir/hack/markdownlint.sh "${@}"
 fi;
 

--- a/processes/roadmap.md
+++ b/processes/roadmap.md
@@ -42,4 +42,3 @@ An inactive issue in one of the releases (marked as stale) can be moved back to
 the `Backlog` column, and issues in the `feature requests` column that are not
 actual feature proposals but issues related to metal3-docs repository can be
 removed from the project.
-


### PR DESCRIPTION
mdl 0.12 moves unordered list indentation from 2 spaces to 3 spaces due Kramdown requirements.

Pin markdownlint image to 0.12 (with SHA), and fix all markdown comply with mdl 0.12.