### PR TITLE
remove hwcc from all-owners.sh

### DIFF
--- a/maintainers/all-owners.sh
+++ b/maintainers/all-owners.sh
@@ -3,7 +3,6 @@
 REPOS=" \
   baremetal-operator \
   cluster-api-provider-metal3 \
-  hardware-classification-controller \
   ip-address-manager \
   ironic-agent-image \
   ironic-client \


### PR DESCRIPTION
HWCC has been archived, remove it from all-owners.sh script, but leave it in documentation for time being.