### PR TITLE
maintainers: update all-owners.sh and ALL-OWNERS

### DIFF
--- a/maintainers/ALL-OWNERS
+++ b/maintainers/ALL-OWNERS
@@ -3,25 +3,19 @@
 
 approvers:
 - andfasano
-- ashughorla
 - bfournie
 - derekhiggins
 - dtantsur
 - elfosardo
 - furkatgofurov7
-- hroyrh
-- imain
+- honza
 - iurygregory
 - kashifest
-- knowncitizen
-- ogelbukh
-- ravipwaghmare
-- russellb
-- stbenjam
-- xenwar
 - zaneb
 
 emeritus_approvers:
- - maelk
- - hardys
- - fmuyassarov
+- fmuyassarov
+- hardys
+- maelk
+- russellb
+- xenwar

--- a/maintainers/all-owners.sh
+++ b/maintainers/all-owners.sh
@@ -1,53 +1,75 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# usage: ./all-owners.sh > ALL-OWNERS
+#
 
-REPOS=" \
-  baremetal-operator \
-  cluster-api-provider-metal3 \
-  ip-address-manager \
-  ironic-agent-image \
-  ironic-client \
-  ironic-image \
-  ironic-hardware-inventory-recorder-image \
-  ironic-ipa-downloader \
-  mariadb-image \
-  metal3-io.github.io \
-  metal3-dev-env \
-  metal3-docs \
-  metal3-helm-chart \
-  project-infra \
-  static-ip-manager-image \
-"
+set -eu
 
-all_owners_raw() {
-  for repo in $REPOS; do
-    if [ "$repo" = "metal3-io.github.io" ]; then
-      filter='.filters.".*".approvers'
-    else
-      filter='.approvers'
+declare -a REPOS=(
+    baremetal-operator
+    cluster-api-provider-metal3
+    ip-address-manager
+    ironic-agent-image
+    ironic-client
+    ironic-image
+    ironic-ipa-downloader
+    mariadb-image
+    metal3-dev-env
+    metal3-docs
+    metal3-io.github.io
+    project-infra
+    static-ip-manager-image
+)
+
+declare -a OWNER_TYPES=(
+    approvers
+    emeritus_approvers
+)
+
+
+# check dependencies are in place - yq is not commonly available
+# as os package, and yq from Ubuntu snap is incompatible
+INSTALL_URL="https://github.com/mikefarah/yq/issues/488"
+command -v yq &>/dev/null || { echo >&2 "fatal: yq not found: see ${INSTALL_URL}"; exit 1; }
+
+all_owners_raw()
+{
+    owner_type="${1:?need to pass in one of: approvers, reviewers, emeritus_approvers, emeritus_reviewers}"
+
+    for repo in "${REPOS[@]}"; do
+        if [ "${repo}" = "metal3-io.github.io" ]; then
+            filter=".filters.\".*\".${owner_type}"
+        else
+            filter=".${owner_type}"
+        fi
+
+        git ls-remote -q --exit-code --heads "https://github.com/metal3-io/${repo}" main >/dev/null 2>&1
+        retVal=$?
+
+        if [ ${retVal} -eq 0 ]; then
+            branch='main'
+        elif [ ${retVal} -ne 0 ]; then
+            if [ "${repo}" = "metal3-io.github.io" ]; then
+            branch='source'
+        else
+            branch='master'
+        fi
     fi
-    git ls-remote -q --exit-code --heads https://github.com/metal3-io/$repo main >/dev/null 2>&1
-    retVal=$?
-    if [ $retVal -eq 0 ]; then
-      branch='main'
-    elif [ $retVal -ne 0 ]; then
-      if [ "$repo" = "metal3-io.github.io" ]; then
-        branch='source'
-      else
-        branch='master'
-      fi
-    fi
-    curl -s "https://raw.githubusercontent.com/metal3-io/$repo/$branch/OWNERS" | \
-      yq -y $filter | \
-      grep -v "null" | \
-      grep -v "\.\.\."
-  done
+
+    # NOTE: yq -y is not supported by any recent version of yq
+    curl -s "https://raw.githubusercontent.com/metal3-io/${repo}/${branch}/OWNERS" | \
+        yq "${filter}" | \
+        grep -v "null" | \
+        grep -v "\.\.\."
+    done
 }
 
 echo "# All approvers from all top-level OWNERS files"
 echo "# See metal3-docs/maintainers/all-owners.sh"
-echo
-echo "approvers:"
 
-all_owners_raw | \
-  tr '[:upper:]' '[:lower:]' | \
-  sort -u
+for owner in "${OWNER_TYPES[@]}"; do
+    echo -e "\n${owner}:"
+    all_owners_raw "${owner}" | \
+        tr '[:upper:]' '[:lower:]' | \
+        sort -u
+done


### PR DESCRIPTION
Besides recent cleanup of HWCC, the all-owners.sh script needs a little freshing up. Proper coding style, proper "set -eu" and checking the uncommon "yq" dependency with installation instructions if its not present. It also didn't support what we actually wanted to have in ALL-OWNERS file, including emeritus_approvers for example. In addition, script now supports generating reviewers and emeritus_reviewers in case such list is needed.

Further, removed a long-time ago archived helm-chart repo, and regenerated ALL-OWNERS file to be up to date.

ALL-OWNERS list needs to be up to date as it is used and linked in the CNCF incubation application. Everyone who is removed there is solely because they no longer have a approver or emeritus approver role in any of the active OWNERS files, and everyone who is added is there for the same reason.