### PR TITLE
update user-guide url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Kubernetes interfaces.
 
 ## Documentation
 
-Please see our [user-guide](https://metal3io.netlify.app/) to familiarize yourself with Metal³ and its features. We are currently in the process of writing
+Please see our [user-guide](https://book.metal3.io/) to familiarize yourself with Metal³ and its features. We are currently in the process of writing
 the user-guide. As such, not all the topics might be covered yet.
 
 ## Community

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -7,5 +7,5 @@ Please do:
 
 In this repository security reports are handled according to the
 Metal3-io project's security policy. For more information about the security
-policy consult the User-Guide [here](https://metal3io.netlify.app/security_policy.html).
+policy consult the User-Guide [here](https://book.metal3.io/security_policy.html).
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -30,7 +30,7 @@ The final content is built on the fly by Netlify as such, we don't store it on G
 
 ## What's the URL of the current user-guide
 
-[https://metal3io.netlify.app/](https://metal3io.netlify.app/)
+[https://book.metal3.io/](https://book.metal3.io/)
 
 ## How to check book content when reviewing a GitHub patch
 


### PR DESCRIPTION
Our user-guide is now properly hosted at https://book.metal3.io/