### PR TITLE
update default RDO OS from Centos8 to Centos9

### DIFF
--- a/docs/user-guide/src/ironic/ironic-python-agent.md
+++ b/docs/user-guide/src/ironic/ironic-python-agent.md
@@ -2,7 +2,7 @@
 
 [IPA](https://docs.openstack.org/ironic-python-agent/latest/) is a service written in python that runs within a ramdisk. It provides remote access to `ironic` and `ironic-inspector` services to perform various operations on the managed server. It also sends information about the server to `Ironic`.
 
-By default, RDO ramdisks from [registry](https://images.rdoproject.org/centos8/master/rdo_trunk) is used. However, another remote registry or a local IPA archive can be specified.
+By default, RDO ramdisks from [registry](https://images.rdoproject.org/centos9/master/rdo_trunk/current-tripleo/) is used. However, another remote registry or a local IPA archive can be specified.
 [ipa-downloader](https://github.com/metal3-io/ironic-ipa-downloader) is responsible for downloading the IPA ramdisk image to a shared volume from where the nodes are able to retrieve it.
 
 ## Data flow


### PR DESCRIPTION
Update documentation to match: https://github.com/Nordix/metal3-dev-tools/pull/658

/hold