### PR TITLE
remove section about prow flake and workflows

### DIFF
--- a/docs/user-guide/src/flake/prow.md
+++ b/docs/user-guide/src/flake/prow.md
@@ -4,10 +4,6 @@
 
 At times you will find multiple PR have passed all the tests and also have the required labels `approve` and `lgtm`. All the necessary checks have passed but prow cannot merge them. In such cases, it is mostly found that one of the PRs are not rebased properly. You have to put a hold on that PR and the other PR should go in. Once you rebase and push the first PR, that should also go in without any issue. So `/hold` should do the trick and prow should be able to merge the PR one by one.
 
-## Github Workflow changing PRs not getting merged
-
-PRs which are modifying/adding files in `.github/workflows/` directory do not get merged automatically by Prow. These PRs tend to get stuck inspite of all the tests passed and all the labels present. We have identified that the reason for this is the branch not being present in `upstream` (metal3-io) but in origin (`Nordix`, or other forks). We did not identify the reason behind it. The solution is to push the branch in `upstream`. Once prow detects the branch is present in `upstream`, it will be able to merge the local branch. You don't have to open a PR from `upstream` branch. Only its existense is enough. However only people who have elevated permissions can push branches `upstream` for safety reasons. So if you face such issue please ask assistance by emailing `estjorvas@est.tech`.
-
 ## Useful links
 
 [Maintainers guide to tide](https://docs.prow.k8s.io/docs/components/core/tide/maintainers/#expected-behavior-that-might-seem-strange)

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -33,8 +33,8 @@ the following in their interaction with the project:
 - Contribution of significant new features through the patch submission
   process where:
 
-  - Submissions are free of obvious critical defects
-  - Submissions do not typically require many iterations of improvement
+   - Submissions are free of obvious critical defects
+   - Submissions do not typically require many iterations of improvement
     to be accepted
 
 - Consistent participation in code review of other's patches, including


### PR DESCRIPTION
Prow flake about not merging workflow related PRs has been solved. Remove that.

(Issue was missing "workflow" permission for the metal3-io-bot token)