### PR TITLE
Updated TODO for Ironic installation

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-metal-kubed.com

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+metal-kubed.com

--- a/docs/user-guide/src/capm3/installation_guide.md
+++ b/docs/user-guide/src/capm3/installation_guide.md
@@ -11,7 +11,7 @@ install them yourself.
 
 1. Install `clusterctl`, refer to Cluster API [book](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl) for installation instructions.
 1. Install `kustomize`, refer to official instructions [here](https://kubectl.docs.kubernetes.io/installation/kustomize/).
-1. Install Ironic, refer to [TODO](TODO).
+1. Install Ironic, refer to [TODO](https://book.metal3.io/ironic/ironic_installation.html).
 1. Install Baremetal Operator, refer to [TODO](TODO).
 1. Install Cluster API core compoenents i.e., core, bootstrap and control-plane providers. This will also install cert-manager, if it is not already installed.
 

--- a/docs/user-guide/src/capm3/installation_guide.md
+++ b/docs/user-guide/src/capm3/installation_guide.md
@@ -11,7 +11,7 @@ install them yourself.
 
 1. Install `clusterctl`, refer to Cluster API [book](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl) for installation instructions.
 1. Install `kustomize`, refer to official instructions [here](https://kubectl.docs.kubernetes.io/installation/kustomize/).
-1. Install Ironic, refer to [TODO](https://book.metal3.io/ironic/ironic_installation.html).
+1. Install Ironic, refer to [this page](https://book.metal3.io/ironic/ironic_installation.html).
 1. Install Baremetal Operator, refer to [TODO](TODO).
 1. Install Cluster API core compoenents i.e., core, bootstrap and control-plane providers. This will also install cert-manager, if it is not already installed.
 


### PR DESCRIPTION
Under 4.1 Install cluster-api metal3 provider [TODO](https://book.metal3.io/capm3/TODO) returns an error when clicked so i found the correct [link](https://book.metal3.io/ironic/ironic_installation.html) and updated it