### PR TITLE
Broken links fix in design folder

### DIFF
--- a/design/_template.md
+++ b/design/_template.md
@@ -67,7 +67,7 @@ To get started with this template:
     changes.
 
 The canonical place for the latest set of instructions (and the likely
-source of this file) is [here](/designs/_template.md).
+source of this file) is [here](/design/_template.md).
 
 ## Status
 

--- a/design/community/foundation-proposal.md
+++ b/design/community/foundation-proposal.md
@@ -70,7 +70,7 @@ does a nice job discussing what services they offer projects on the
 - (russellb) Write this proposal.
 - (everyone) Provide feedback on initial proposal, reach consensus.
 - (russellb) If approved, draft the [CNCF Sandbox
-  application](https://github.com/cncf/toc/blob/master/process/project_proposals.adoc)
+  application](https://github.com/cncf/toc/blob/main/process/project_proposals.md)
   first as a draft in this repository.
 - (everyone) Provide feedback on application text, reach consensus.
 - (russellb) Submit Application.
@@ -113,4 +113,4 @@ collaborate with the cluster-api project.
 - Sample application: [KubeVirt sandbox
   application](https://github.com/cncf/toc/pull/265)
 - [CNCF Graduation
-  Criteria](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc)
+  Criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md)


### PR DESCRIPTION
3 broken links in the design folder 
1. Corrected [here](https://github.com/metal3-io/metal3-docs/blob/main/design/_template.md) on this [page](https://github.com/metal3-io/metal3-docs/blob/main/design/_template.md)
2. Corrected [CNCF Sandbox application](https://github.com/cncf/toc/blob/main/process/project_proposals.md), [CNCF Graduation Criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md) on this [page](https://github.com/metal3-io/metal3-docs/blob/main/design/community/foundation-proposal.md)