### PR TITLE
📖 Add Kashif Khan and Lennart Jern as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,13 +4,12 @@ approvers:
  - andfasano
  - dtantsur
  - furkatgofurov7
+ - kashifest
+ - lentzi90
  - zaneb
 
 reviewers:
  - Rozzii
- - kashifest
- - lentzi90
-
 
 emeritus_approvers:
  - maelk


### PR DESCRIPTION
After following the process described in our community documentation
[1], there were no objections to adding Kashif Khan and Lennart Jern as approvers to repositories root OWNERS file.

[1] https://github.com/metal3-io/metal3-docs/tree/master/maintainers

/cc @kashifest @lentzi90 @andfasano @dtantsur @zaneb 