### PR TITLE
Latest broken links update

### DIFF
--- a/design/_template.md
+++ b/design/_template.md
@@ -67,7 +67,7 @@ To get started with this template:
     changes.
 
 The canonical place for the latest set of instructions (and the likely
-source of this file) is [here](/designs/_template.md).
+source of this file) is [here](/design/_template.md).
 
 ## Status
 

--- a/design/baremetal-operator/implicit-boot-mode.md
+++ b/design/baremetal-operator/implicit-boot-mode.md
@@ -106,7 +106,7 @@ that is also easy to document.
 The proposal, therefore, is to always use BIOS mode when using IPMI
 and to prefer UEFI when using Redfish. We can implement this by adding
 a new method to the [AccessDetails
-interface](https://github.com/metal3-io/baremetal-operator/blob/main/pkg/bmc/access.go#L27)
+interface](https://github.com/metal3-io/baremetal-operator/blob/dabe5e14bafa00db6ccb37f1169c74ee3dac4425/pkg/hardwareutils/bmc/access.go#L47)
 to return the properties for a host, including the `boot_mode`. This
 API is consistent with other similar methods in that class that return
 other sets of data passed to Ironic when a host is registered.
@@ -141,7 +141,7 @@ values later for other hardware platforms.
 ## Design Details
 
 - Update the [AccessDetails
-  interface](https://github.com/metal3-io/baremetal-operator/blob/main/pkg/bmc/access.go#L27)
+  interface](https://github.com/metal3-io/baremetal-operator/blob/dabe5e14bafa00db6ccb37f1169c74ee3dac4425/pkg/hardwareutils/bmc/access.go#L47)
   to include the new method, `NodeProperties()`.
 - Update each implementation of the interface to include the new
   method with at least a static return value.

--- a/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md
+++ b/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md
@@ -25,7 +25,7 @@ recovery of unhealthy nodes we need a programmatic way to put them back into a
 safe and healthy state.
 
 The Cluster API includes an optional
-[MachineHealthcheck](https://cluster-api.sigs.k8s.io/tasks/healthcheck.html) (MHC)
+[MachineHealthcheck](https://cluster-api.sigs.k8s.io/developer/architecture/controllers/machine-health-check.html) (MHC)
 component that implements automated health checking capability, and the with
 [External Remediation proposal](https://github.com/kubernetes-sigs/cluster-api/pull/3190)
 it will be possible to plug in Metal3 specific remediation strategies to

--- a/design/cluster-api-provider-metal3/node_reuse.md
+++ b/design/cluster-api-provider-metal3/node_reuse.md
@@ -220,5 +220,7 @@ None
 
 ## References
 
-- Remediation proposal in Metal3: [Remediation](https://github.com/metal3-io/metal3-docs/blob/main/design/capm3-remediation-controller-proposal.md)
+
+- Remediation proposal in Metal3: [Remediation](https://github.com/metal3-io/metal3-docs/blob/c4a981275e6bf7cf8b77a274d7db83089b6edd4a/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md)
+
 - Disable disk cleaning proposal in Metal3: [Disable disk cleaning](https://github.com/metal3-io/metal3-docs/blob/main/design/cluster-api-provider-metal3/allow_disabling_node_disk_cleaning.md)

--- a/design/community/foundation-proposal.md
+++ b/design/community/foundation-proposal.md
@@ -70,7 +70,7 @@ does a nice job discussing what services they offer projects on the
 - (russellb) Write this proposal.
 - (everyone) Provide feedback on initial proposal, reach consensus.
 - (russellb) If approved, draft the [CNCF Sandbox
-  application](https://github.com/cncf/toc/blob/master/process/project_proposals.adoc)
+  application](https://github.com/cncf/toc/blob/main/process/project_proposals.md)
   first as a draft in this repository.
 - (everyone) Provide feedback on application text, reach consensus.
 - (russellb) Submit Application.
@@ -113,4 +113,4 @@ collaborate with the cluster-api project.
 - Sample application: [KubeVirt sandbox
   application](https://github.com/cncf/toc/pull/265)
 - [CNCF Graduation
-  Criteria](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc)
+  Criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md)

--- a/design/hardware-classification-controller/expected-hardware-configuration-validation.md
+++ b/design/hardware-classification-controller/expected-hardware-configuration-validation.md
@@ -44,7 +44,7 @@ into baremetal host.
 ### Implementation Details/Notes/Constraints
 
 Please refer to the [metal3 spec for
-bare-metal](https://github.com/metal3-io/baremetal-operator/blob/main/deploy/crds/metal3.io_baremetalhosts_crd.yaml).
+bare-metal](https://github.com/metal3-io/baremetal-operator/blob/dabe5e14bafa00db6ccb37f1169c74ee3dac4425/config/crd/bases/metal3.io_baremetalhosts.yaml).
 
 - Below is sample yaml of Kind HardwareClassification.
 

--- a/design/ironic-debuggability-improvement.md
+++ b/design/ironic-debuggability-improvement.md
@@ -71,7 +71,7 @@ ironic-provisioning-log-watch.sh will be created in
 ironic-inspection-log-watch.sh will be created in
 <https://github.com/metal3-io/ironic-inspector-image>
 Both scripts will be added as new container entry points to
-<https://github.com/metal3-io/baremetal-operator/blob/main/ironic-deployment/ironic/ironic.yaml>
+<https://github.com/metal3-io/baremetal-operator/blob/dabe5e14bafa00db6ccb37f1169c74ee3dac4425/ironic-deployment/base/ironic.yaml>
 
 ### Implementation Details/Notes/Constraints
 

--- a/processes/releasing.md
+++ b/processes/releasing.md
@@ -1,0 +1,134 @@
+# Releasing
+
+This document details the high-level process of creating a Metal3 release, and
+the post-release actions required to add new release branches to the CI.
+
+Note the [TODO](#todo) section in the end.
+
+## Process
+
+High-level release process we followed in case it makes it clearer:
+
+1. [Release IPAM](https://github.com/metal3-io/ip-address-manager/blob/main/docs/releasing.md)
+1. [Release BMO](https://github.com/metal3-io/baremetal-operator/blob/main/docs/releasing.md)
+1. [Release CAPM3](https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/docs/releasing.md)
+1. Update Metal3 dev-env and CI to support new releases
+
+## Update Metal3 dev-env and CI to support new releases
+
+If a new minor or major release was published, we need to make changes in
+Metal3 dev-env and CI.
+
+### Tag Ironic and Mariadb images
+
+After releasing `v1.x.y` version of CAPM3, create an annotated tag with `capm3-`
+prefix + release version in
+[ironic-image](https://github.com/metal3-io/ironic-image) and
+[mariadb-image](https://github.com/metal3-io/mariadb-image) Github
+repositories.
+
+```bash
+git tag -s -a capm3-v1.x.y -m capm3-v1.x.y [optional sha, or tag^{}]
+git push origin capm3-v1.x.y
+```
+
+After this, [Ironic](https://quay.io/repository/metal3-io/ironic) and
+[MariaDB](https://quay.io/repository/metal3-io/mariadb) container images will
+be built automatically  with `capm3-v1.x.y` tag in Quay. Verify the build is
+triggered, as often Quay has disabled the build trigger due build failures or
+other reasons.
+
+### Create Jenkins jobs
+
+Two Jenkins jobs need to be created in
+[JJB](https://gerrit.nordix.org/plugins/gitiles/infra/cicd/+/refs/heads/master/jjb/metal3/):
+
+- a periodic job that runs on a regular basis.
+- a PR verification job that is triggered by a keyword on a PR targeted for that
+  release branch.
+
+[Prior art](https://gerrit.nordix.org/c/infra/cicd/+/17709) that adds support
+for periodics and PR jobs.
+
+### Change project-infra to support new branches
+
+We also need to change project-infra keywords for required tests for some of
+the repositories.
+
+[Prior art](https://github.com/metal3-io/project-infra/pull/496)
+
+### Configure Metal3 dev-env to support new branches
+
+Metal3-dev-env needs to be modified to support new release branches and
+tags with supported combination of component versions for testing.
+
+[Prior art](https://github.com/metal3-io/metal3-dev-env/pull/1222)
+
+### Configure Metal3 dev-tools to sync new release branches to Nordix
+
+Dev-tools synchronizes `metal3-io` changes to the `Nordix` fork for the EST
+folks.
+
+[Prior art](https://github.com/Nordix/metal3-dev-tools/pull/672)
+
+### Update testing matrix documentation
+
+Update
+[version support documentation](https://github.com/metal3-io/metal3-docs/blob/main/docs/user-guide/src/version_support.md)
+including Testing Matrix to reflect the new release and the combination of
+components that are tested in periodic jobs.
+
+[Prior art](https://github.com/metal3-io/metal3-docs/pull/330)
+
+## Announcements
+
+We announce the release in Kubernetes slack on `#cluster-api-baremetal` channel
+and through the `metal3-dev` group mailing list.
+
+Email template:
+
+```text
+Hey folks,
+
+CAPM3 v1.x.y, IPAM v1.x.y and BMO v0.x.y minor releases are out now!
+Release notes can be found here: CAPM3 release notes[1], IPAM release notes[2] and BMO release notes[3].
+
+Thanks to all our contributors!
+
+[1] https://github.com/metal3-io/cluster-api-provider-metal3/releases/tag/v1.x.y
+[2] https://github.com/metal3-io/ip-address-manager/releases/tag/v1.x.y
+[3] https://github.com/metal3-io/baremetal-operator/releases/tag/v0.x.y
+```
+
+Slack template:
+
+```text
+Hey folks,
+
+CAPM3 v1.x.y, IPAM v1.x.y and BMO v0.x.y minor releases are out now :tada::metal3:!
+
+Release notes can be found here:
+- CAPM3 v1.x.y: https://github.com/metal3-io/cluster-api-provider-metal3/releases/tag/v1.x.y
+- IPAM v1.x.y: https://github.com/metal3-io/ip-address-manager/releases/tag/v1.x.y
+- BMO: v0.x.y: https://github.com/metal3-io/baremetal-operator/releases/tag/v0.x.y
+
+Thanks to all our contributors! :blush:
+```
+
+## TODO
+
+BMO releasing to be discussed.
+
+1. BMO releasing and maintenance
+   - BMO does not have release branches, only tags off the `main` branch
+   - Without release branches, maintaining BMO versions that are coupled with
+     CAPM3 releases is impossible
+1. BMO dependencies
+   - BMO contains `keepalived`
+     ([within BMO repo](https://github.com/metal3-io/baremetal-operator/tree/main/resources/keepalived-docker))
+1. BMO makes strong assumption about the exact configuration of Ironic.
+   However, [ironic-image](https://github.com/metal3-io/ironic-image) is
+   currently branchless.
+1. BMO makes assumption about the exact configuration of MariaDB.
+   However, [mariadb-image](https://github.com/metal3-io/mariadb-image) is
+   currently branchless.


### PR DESCRIPTION
Updated 4 of 5 GitHub broken links to Permalinks for #328 
- https://github.com/metal3-io/baremetal-operator/blob/main/pkg/bmc/access.go
- https://github.com/metal3-io/metal3-docs/blob/main/design/capm3-remediation-controller-proposal.md
- https://github.com/metal3-io/baremetal-operator/blob/main/deploy/crds/metal3.io_baremetalhosts_crd.yaml
- https://github.com/metal3-io/metal3-docs/blob/main/design/baremetal-operator/re-introspection-interface.md
- https://cluster-api.sigs.k8s.io/tasks/healthcheck.html