### PR TITLE
Latest broken links update

### DIFF
--- a/design/baremetal-operator/implicit-boot-mode.md
+++ b/design/baremetal-operator/implicit-boot-mode.md
@@ -106,7 +106,7 @@ that is also easy to document.
 The proposal, therefore, is to always use BIOS mode when using IPMI
 and to prefer UEFI when using Redfish. We can implement this by adding
 a new method to the [AccessDetails
-interface](https://github.com/metal3-io/baremetal-operator/blob/main/pkg/bmc/access.go#L27)
+interface](https://github.com/metal3-io/baremetal-operator/blob/93cd6bdae72ff44a3b68cea7d549abd758d27838/pkg/hardwareutils/bmc/access.go#L47)
 to return the properties for a host, including the `boot_mode`. This
 API is consistent with other similar methods in that class that return
 other sets of data passed to Ironic when a host is registered.
@@ -141,7 +141,7 @@ values later for other hardware platforms.
 ## Design Details
 
 - Update the [AccessDetails
-  interface](https://github.com/metal3-io/baremetal-operator/blob/main/pkg/bmc/access.go#L27)
+  interface](https://github.com/metal3-io/baremetal-operator/blob/93cd6bdae72ff44a3b68cea7d549abd758d27838/pkg/hardwareutils/bmc/access.go#L47)
   to include the new method, `NodeProperties()`.
 - Update each implementation of the interface to include the new
   method with at least a static return value.

--- a/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md
+++ b/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md
@@ -25,7 +25,7 @@ recovery of unhealthy nodes we need a programmatic way to put them back into a
 safe and healthy state.
 
 The Cluster API includes an optional
-[MachineHealthcheck](https://cluster-api.sigs.k8s.io/tasks/healthcheck.html) (MHC)
+[MachineHealthcheck](https://cluster-api.sigs.k8s.io/developer/architecture/controllers/machine-health-check.html) (MHC)
 component that implements automated health checking capability, and the with
 [External Remediation proposal](https://github.com/kubernetes-sigs/cluster-api/pull/3190)
 it will be possible to plug in Metal3 specific remediation strategies to

--- a/design/cluster-api-provider-metal3/node_reuse.md
+++ b/design/cluster-api-provider-metal3/node_reuse.md
@@ -220,5 +220,5 @@ None
 
 ## References
 
-- Remediation proposal in Metal3: [Remediation](https://github.com/metal3-io/metal3-docs/blob/main/design/capm3-remediation-controller-proposal.md)
+- Remediation proposal in Metal3: [Remediation](https://github.com/metal3-io/metal3-docs/blob/c4a981275e6bf7cf8b77a274d7db83089b6edd4a/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md)
 - Disable disk cleaning proposal in Metal3: [Disable disk cleaning](https://github.com/metal3-io/metal3-docs/blob/main/design/cluster-api-provider-metal3/allow_disabling_node_disk_cleaning.md)

--- a/design/hardware-classification-controller/expected-hardware-configuration-validation.md
+++ b/design/hardware-classification-controller/expected-hardware-configuration-validation.md
@@ -44,7 +44,7 @@ into baremetal host.
 ### Implementation Details/Notes/Constraints
 
 Please refer to the [metal3 spec for
-bare-metal](https://github.com/metal3-io/baremetal-operator/blob/main/deploy/crds/metal3.io_baremetalhosts_crd.yaml).
+bare-metal](https://github.com/metal3-io/baremetal-operator/blob/93cd6bdae72ff44a3b68cea7d549abd758d27838/config/crd/bases/metal3.io_baremetalhosts.yaml).
 
 - Below is sample yaml of Kind HardwareClassification.
 

--- a/design/ironic-debuggability-improvement.md
+++ b/design/ironic-debuggability-improvement.md
@@ -71,7 +71,7 @@ ironic-provisioning-log-watch.sh will be created in
 ironic-inspection-log-watch.sh will be created in
 <https://github.com/metal3-io/ironic-inspector-image>
 Both scripts will be added as new container entry points to
-<https://github.com/metal3-io/baremetal-operator/blob/main/ironic-deployment/ironic/ironic.yaml>
+<https://github.com/metal3-io/baremetal-operator/blob/dabe5e14bafa00db6ccb37f1169c74ee3dac4425/ironic-deployment/base/ironic.yaml>
 
 ### Implementation Details/Notes/Constraints
 


### PR DESCRIPTION
Fixed broken links on these files [1](https://github.com/metal3-io/metal3-docs/blob/main/design/baremetal-operator/implicit-boot-mode.md), [2](https://github.com/metal3-io/metal3-docs/blob/main/design/ironic-debuggability-improvement.md), [3](https://github.com/metal3-io/metal3-docs/blob/main/design/cluster-api-provider-metal3/node_reuse.md), [4](https://github.com/metal3-io/metal3-docs/blob/main/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md) and [5](https://github.com/metal3-io/metal3-docs/blob/main/design/baremetal-operator/implicit-boot-mode.md) following the #328 issue

cc: @tuminoid 