### PR TITLE
📖  Update deprecated bmh ready state to available in the user guide

### DIFF
--- a/docs/user-guide/src/bmo/detached_annotation.md
+++ b/docs/user-guide/src/bmo/detached_annotation.md
@@ -3,7 +3,7 @@
 The detached annotation provides a way to prevent management of a BareMetalHost.
 It works by deleting the host information from Ironic without triggering deprovisioning.
 The BareMetal Operator will recreate the host in Ironic again once the annotation is removed.
-This annotation can be used with BareMetalHosts in `Provisioned`, `ExternallyProvisioned`, `Ready` or `Available` states.
+This annotation can be used with BareMetalHosts in `Provisioned`, `ExternallyProvisioned` or `Available` states.
 
 Normally, deleting a BareMetalHost will always trigger deprovisioning.
 This can be problematic and unnecessary if we just want to, for example, move the BareMetalHost from one cluster to another.

--- a/docs/user-guide/src/bmo/inspect_annotation.md
+++ b/docs/user-guide/src/bmo/inspect_annotation.md
@@ -1,9 +1,9 @@
 # Inspect annotation
 
-The inspect annotation can be used to request the baremetal operator to (re-)inspect a `Ready` BareMetalHost.
+The inspect annotation can be used to request the baremetal operator to (re-)inspect an `Available` BareMetalHost.
 This is useful in case there were hardware changes for example.
-Note that it is only possible to do this when BareMetalHost is in `Ready` state.
-If an inspection request is made while BareMetalHost is any other state than Ready, the request will be ignored.
+Note that it is only possible to do this when BareMetalHost is in `Available` state.
+If an inspection request is made while BareMetalHost is any other state than `Available`, the request will be ignored.
 
 To request a new inspection, simply annotating the host with `inspect.metal3.io` is enough.
 Once inspection is requested, you should see the BMH in inspecting state until inspection is completed, and by the end of inspection the `inspect.metal3.io` annotation will be removed automatically.
@@ -34,6 +34,6 @@ Why is this needed?
 
 Caveats:
 
-- It is only possible to inspect a BareMetalHost when it is in `Ready` state.
+- It is only possible to inspect a BareMetalHost when it is in `Available` state.
 
 Note: For other use cases, like disabling inspection or providing externally gathered inspection data, see [external inspection](./external_inspection.md).


### PR DESCRIPTION
BMH `ready` state is not valid any more it was replaced by `available` state