### PR TITLE
Attach non-bootable iso to BareMetalHost proposal

### DIFF
--- a/design/baremetal-operator/bmh_non-bootable_iso.md
+++ b/design/baremetal-operator/bmh_non-bootable_iso.md
@@ -56,6 +56,13 @@ to attach a non-bootable iso image to hosts.
 We may consider adding support for HTTP credentials and TLS settings in the future
 but it's outside the scope of this proposal.
 
+As part of this proposal, the DataImage attachment will happen after the next reboot
+because many hardwares need a reboot for attaching an image. For example, Dell iDrac
+usually operates in terms of tasks, so once we create a task to attach a virtual
+media, it will wait for the next reboot.
+But we may add such an option in the future, something like - `immediate: true`,
+to immediately attach the DataImage without waiting for reboot, for compatible hardware.
+
 **Note** : As part of this proposal, the dataImage will be attached after the node
 has been Provisioned or ExternallyProvisioned.
 

--- a/design/baremetal-operator/bmh_non-bootable_iso.md
+++ b/design/baremetal-operator/bmh_non-bootable_iso.md
@@ -1,0 +1,73 @@
+# Add non-bootable iso attach API to BareMetalHost
+
+## Status
+
+Implementable
+
+## Summary
+
+Add a new field in BareMetalHost so that it is possible to attach a generic
+non-bootable iso image via Ironic, after the host has been provisioned.
+
+## Motivation
+
+In certain scenarios it is desirable to attach a non-bootable iso image
+to a system after provisioning has finished, for example :
+
+As a config data disk to do some post provisioning configuration for the
+system.
+
+For troubleshooting of the node.
+
+### Goals
+
+Expose the Ironic API to attach non-bootable iso images via Metal3.
+
+## Proposal
+
+### BMO Proposal
+
+Add a new optional section in the BareMetalHost spec containing details of the
+non-bootable iso image, example :
+
+```yaml
+  spec:
+    dataImage:
+      url: http://1.2.3.4/image.iso
+      username: metal
+      password: password
+      insecure: false
+```
+
+Note that in this case, the iso image will be attached after the node
+has been provisioned or ExternallyProvisioned.
+
+### Ironic Proposal
+
+The [proposal](https://bugs.launchpad.net/ironic/+bug/2033288) for exposing this functionaility in Ironic has been
+accepted by the upstream Ironic community.
+
+## Design Details
+
+Add an optional section `DataImage` to `BareMetalHostSpec`, with sub-fields
+`Url`, `Username`, `Password`, `Insecure`.
+
+## Dependencies
+
+There is a dependency on the implementation(based on the proposal shared
+above) on Ironic side to finish for this feature to work. But this doesn't
+block the development of the BMO API.
+
+## Upgrade / Downgrade Strategy
+
+This feature is added to the BareMetalHost API as an optional field, so all the
+existing BareMetalHost definitions should continue to work as before.
+
+This feature will become available after upgrade, and downgrade is also
+possible as long as the corresponding fields are not used.
+
+## Alternatives
+
+We can also achieve this using the existing `BMH.Spec.Image` field, but this
+attempts to change the boot order of the system and relies on the host to
+fallback to the installed system when booting the image fails.

--- a/design/baremetal-operator/bmh_non-bootable_iso.md
+++ b/design/baremetal-operator/bmh_non-bootable_iso.md
@@ -77,7 +77,7 @@ and `Namespace` as the `BareMetalHost` where we are attaching the image.
 To attach an ISO, first the `DataImage` CR object is created and then it is attached to the
 BMH on its next reboot/power on.
 
-The `BareMetalHostStatus` will cache the image details including the attachment
+The `DataImage` `Status` will cache the image details including the attachment
 status, which will inform us if the attachment succeeded and can also be used
 for detachment - either when the attachment fails and we retry or when the user
 explicitly requests detachment by deleting the `DataImage` CRD that corresponds to a BMH.
@@ -95,8 +95,19 @@ Then, on the next reboot/power-on of the BMH, the `DataImage` will be attached a
 `Status` will be updated to reflect the status of the attachment, including which image was attached.
 In case of detachment of the ISO(`DataImage`), similar process will be followed where the actual
 detachment will happen on the next reboot/power-on and the `DataImage` Status will reflect the status
-of detachment, example : success, number of failures. The finalizer will also be removed once the
+of detachment, example : number of failures. The finalizer will also be removed once the
 detachment succeeds.
+Here is an example of what the `DataImage` `Status` might look like:
+
+```yaml
+status:
+  lastReconciliation: "2024-01-01T12:00:00Z"
+  error:
+    count: 0
+    message: ""
+  attachedImage:
+    url: "http://example.com/images/dataimage.iso"
+```
 
 Since the attachment of the ISO happens when a BMH reconcile is triggered as a result of BMH
 reboot/power on, so handling the attachment/detachment of dataImage when the host reaches steady state (refer [`actionManageSteadyState` function](https://github.com/metal3-io/baremetal-operator/blob/9ce684e6462a6ab55ff650cb6c11f9ba1ffb395d/controllers/metal3.io/baremetalhost_controller.go#L1414) )

--- a/design/baremetal-operator/bmh_non-bootable_iso.md
+++ b/design/baremetal-operator/bmh_non-bootable_iso.md
@@ -7,7 +7,7 @@ Implementable
 ## Summary
 
 Add a new field in BareMetalHost so that it is possible to attach a generic
-non-bootable iso image via Ironic, after the host has been provisioned.
+non-bootable ISO (a CD "ISO 9660" image) image via Ironic, after the host has been provisioned.
 
 ## Motivation
 
@@ -25,7 +25,8 @@ Expose the Ironic API to attach non-bootable iso images via Metal3.
 
 ### Non-Goals
 
-Supporting non-ISO images such as a USB stick.
+Supporting non-ISO images i.e. media types other than CD/DVD, supporting
+drivers other than Redfish and its derived drivers.
 
 ## Proposal
 
@@ -33,6 +34,16 @@ Supporting non-ISO images such as a USB stick.
 
 Add a new optional section in the BareMetalHost spec containing details of the
 non-bootable iso image, example :
+
+#### Current design
+
+```yaml
+  spec:
+    dataImage:
+      url: http://1.2.3.4/image.iso
+```
+
+#### Desired future design
 
 ```yaml
   spec:
@@ -56,8 +67,8 @@ data:
   password: cGFzc3dvcmQ=
 ```
 
-Note that in this case, the iso image will be attached after the node
-has been provisioned or ExternallyProvisioned.
+**Note** : As part of this proposal, the dataImage will be attached after the node
+has been Provisioned or ExternallyProvisioned.
 
 ### Ironic Proposal
 
@@ -74,23 +85,29 @@ The ISO will be attached when the host is in either the `StateProvisioned` or
 the `StateExternallyProvisioned` state before `actionManageSteadyState` is
 called to maintain the State and manage the host power status.
 
-We want to attach the non-bootable ISO without an extra reboot.
+We want to attach the non-bootable ISO without an extra reboot when both
+attaching the ISO and reboot are requested at the same time.
 
 ### Implementation Details
 
-**ToDo** : Explicitly and clearly define the order of actions for the
-below scenarios.
+As part of the design we are assuming that the user will edit the BareMetalHost
+to add the dataImage spec, and might also request reboot via rebootAnnotation
+or power state change via `online` field.
 
-What should be the order of action for attaching the ISO without an extra
-reboot(i.e attaching when the host is poweredoff), when :
+We want to attach the dataImage first, so handling the attachment/detachment of dataImage
+inside the Reconcile function, after reconciling host data and updating hardware details ([code reference](https://github.com/metal3-io/baremetal-operator/blob/1bb45eef449c942711b1c0937ecff2b10a326eb3/controllers/metal3.io/baremetalhost_controller.go#L152) ), makes sense since
+any power state change (including reboot via rebootAnnotation) will be handled later on via the stateMachine ( [code reference](https://github.com/metal3-io/baremetal-operator/blob/1bb45eef449c942711b1c0937ecff2b10a326eb3/controllers/metal3.io/baremetalhost_controller.go#L222) ).
 
-**Scenario 1** : `externallyProvisioned: true, online: true, dataImage: <set>`
+We need to cache the attached image in `Status` of the BareMetalHost to know if the
+image has been attached. This will also help us determine if a different image is
+attached previously which needs to be detached first before attaching the new
+dataImage. Or if the user delets the dataImage spec and the `Status` contains a
+cached entry, which will again trigger detachment of that image.
 
-* Proposed workflow : "attach dataImage" -> ManageSteadyState
-
-**Scenario 2** : `image: <set>, online: true, dataImage: <set>`
-
-* Proposed workflow : "mount image" -> provision -> "provisioning finished"-> "detach image" -> "attach dataImage" ->  ManageSteadyState
+In case the image fails to attach, we will retry until either the attachment succeeds
+or the user removes the dataImage spec. In case of failure in attachment, we will
+always do a detachment before the next retry, and record the reason for failure in the
+logs.
 
 ## Dependencies
 
@@ -105,6 +122,9 @@ existing BareMetalHost definitions should continue to work as before.
 
 This feature will become available after upgrade, and downgrade is also
 possible as long as the corresponding fields are not used.
+
+Explicit microversion negotiation support has been added to Gophercloud ([pr](https://github.com/gophercloud/gophercloud/pull/2791))
+which can be used in case we don't want to use the master branch for Ironic.
 
 ## Alternatives
 

--- a/design/baremetal-operator/bmh_non-bootable_iso.md
+++ b/design/baremetal-operator/bmh_non-bootable_iso.md
@@ -6,13 +6,14 @@ Implementable
 
 ## Summary
 
-Add a new Custom Resource(CR), `DataImage`, to the cluster which will make it possible,
-using ownerReferences (example : [HostFirmwareSettings](https://github.com/metal3-io/baremetal-operator/blob/9ce684e6462a6ab55ff650cb6c11f9ba1ffb395d/docs/api.md?plain=1#L664)) and same `Name` and `Namespace` as the `BareMetalHost`, to attach a generic non-bootable ISO (a CD "ISO 9660" image) image via Ironic, after the host has been provisioned.
+Add a new Custom Resource(CR), `DataImage`, to the cluster to attach a
+generic non-bootable ISO (a CD "ISO 9660" image) image to a provisioned
+or externallyProvisioned BMH using Ironic.
 
 ## Motivation
 
 In certain scenarios it is desirable to attach a non-bootable iso image
-to a system after provisioning has finished, for example :
+to a system after provisioning has finished, for example:
 
 A configuration ISO can be used to provide first-boot configuration to a host
 deployed from a standard image in advance. An operator may have a pool of
@@ -25,8 +26,8 @@ Expose the Ironic API to attach non-bootable iso images via Metal3.
 
 ### Non-Goals
 
-Supporting non-ISO images i.e. media types other than CD/DVD, supporting
-drivers other than Redfish and its derived drivers.
+* Supporting non-ISO images i.e. media types other than CD/DVD
+* Supporting drivers other than Redfish and its derived drivers.
 
 ## Proposal
 
@@ -44,8 +45,7 @@ metadata:
   name: metal-worker-0
   namespace: metal-cluster
 spec:
-  dataImage:
-    url: http://1.2.3.4/image.iso
+  url: http://1.2.3.4/image.iso
 ```
 
 We will use ownerReferences in the `DataImage` CR to link it to the corresponding `BareMetalHost` object.
@@ -71,34 +71,35 @@ which in this proposal is Redfish.
 
 ## Design Details
 
-Create a new Custom Resource(CR), `DataImage`, with spec field `Url` and same `Name`
+Create a new Custom Resource(CR), `DataImage`, with spec field `Url` and the same `Name`
 and `Namespace` as the `BareMetalHost` where we are attaching the image.
 
-The ISO will be attached when the `DataImage` CR object is created and the
-corresponding ownerReference is added for the `BareMetalHost` object,  which will trigger a
-reconciliation. In case a reboot is requested at the same time using
-`RebootAnnotation`, the ISO will be attached first.
+To attach an ISO, first the `DataImage` CR object is created and then it is attached to the
+BMH on its next reboot/power on.
 
 The `BareMetalHostStatus` will cache the image details including the attachment
 status, which will inform us if the attachment succeeded and can also be used
 for detachment - either when the attachment fails and we retry or when the user
 explicitly requests detachment by deleting the `DataImage` CRD that corresponds to a BMH.
 
-We will introduce a new flag, `NonBootableISOImage`, at the webhook level to validate if a given driver supports the
-non-bootable ISO feature.
+We will introduce a new flag, `NonBootableISOImage` (under `pkg/hardwareutils/bmc`), at the
+webhook level to validate if a given driver supports the non-bootable ISO feature.
 
 ### Implementation Details
 
 As part of the design we are assuming that to attach an image to a BMH object, the user
 will create the corresponding `DataImage` CR (with the same `Name` and `Namespace` as the
-`BareMetalHost` object) with `OwnerReference` to the BMH object.
-At the same time and independently, the user might also request a reboot via rebootAnnotation
-or power state change via `online` field.
+`BareMetalHost` object) and the BMH Controller will add the ownerReference for the corresponding BMH
+to it (example : [HostFirmwareSettings](https://github.com/metal3-io/baremetal-operator/blob/9ce684e6462a6ab55ff650cb6c11f9ba1ffb395d/docs/api.md?plain=1#L664)). Then, on the next reboot/power on
+of the BMH, the `DataImage` will be attached and the `BareMetalHost` Status will be updated to reflect
+the status of attachment, including which image was attached. In case of detachment of ISO, similar process
+will be followed where the actual detachment will happen on the next reboot/power on and the BMH Status
+will reflect the status of detachment, example : success, number of failures.
 
-In such scenarios, we want to attach the dataImage first(before the reboot), so handling the
-attachment/detachment of dataImage when the host reaches steady state (refer [`actionManageSteadyState` function](https://github.com/metal3-io/baremetal-operator/blob/9ce684e6462a6ab55ff650cb6c11f9ba1ffb395d/controllers/metal3.io/baremetalhost_controller.go#L1414) )
-makes sense since we only reach this state when a host has been either provisioned or externallyProvisioned, and also
-any power state change (including reboot via rebootAnnotation) are also handled after the host reaches this state
+Since the attachment of the ISO happens when a BMH reconcile is triggered as a result of BMH
+reboot/power on, so handling the attachment/detachment of dataImage when the host reaches steady state (refer [`actionManageSteadyState` function](https://github.com/metal3-io/baremetal-operator/blob/9ce684e6462a6ab55ff650cb6c11f9ba1ffb395d/controllers/metal3.io/baremetalhost_controller.go#L1414) )
+makes sense since we only reach this state when a host has been either provisioned or externallyProvisioned, and
+any power state changes (including reboot via rebootAnnotation) are also handled after the host reaches this state
 ( refer [`manageHostPower` function](https://github.com/metal3-io/baremetal-operator/blob/1bb45eef449c942711b1c0937ecff2b10a326eb3/controllers/metal3.io/baremetalhost_controller.go#L222) )
 
 We need to cache the attached image along with the attachment status in `Status`

--- a/design/baremetal-operator/bmh_non-bootable_iso.md
+++ b/design/baremetal-operator/bmh_non-bootable_iso.md
@@ -77,16 +77,17 @@ accepted by the upstream Ironic community.
 
 ## Design Details
 
-Add an optional section `DataImage` to `BareMetalHostSpec`, with sub-fields
-`Url`, `CredentialsName`, `DisableCertificateVerification` and a secret
-for dataImage with name `CredentialsName`.
+Add an optional section `DataImage` to `BareMetalHostSpec`, with sub-field
+`Url`.
 
-The ISO will be attached when the host is in either the `StateProvisioned` or
-the `StateExternallyProvisioned` state before `actionManageSteadyState` is
-called to maintain the State and manage the host power status.
+The ISO will be attached when the `BareMetalHost` object is edited to add
+the `DataImage` spec triggering a reconciliation. In case a reboot is requested
+at the same time using `RebootAnnotation`, the ISO will be attached first.
 
-We want to attach the non-bootable ISO without an extra reboot when both
-attaching the ISO and reboot are requested at the same time.
+The `BareMetalHostStatus` will cache the image details, which will inform
+us if the attachment succeeded and will also be used for detachment, either
+when the attachment fails and we retry or when the user explicitly requests
+detachment by removing the `DataImage` spec from `BareMetalHost` object.
 
 ### Implementation Details
 

--- a/design/baremetal-operator/bmh_non-bootable_iso.md
+++ b/design/baremetal-operator/bmh_non-bootable_iso.md
@@ -14,14 +14,18 @@ non-bootable iso image via Ironic, after the host has been provisioned.
 In certain scenarios it is desirable to attach a non-bootable iso image
 to a system after provisioning has finished, for example :
 
-As a config data disk to do some post provisioning configuration for the
-system.
-
-For troubleshooting of the node.
+A configuration ISO can be used to provide first-boot configuration to a host
+deployed from a standard image in advance. An operator may have a pool of
+powered off hosts with operating system already provisioned. Then, adding
+a host to the cluster boils down to powering it on with a configuration ISO provided.
 
 ### Goals
 
 Expose the Ironic API to attach non-bootable iso images via Metal3.
+
+### Non-Goals
+
+Supporting non-ISO images such as a USB stick.
 
 ## Proposal
 
@@ -34,9 +38,22 @@ non-bootable iso image, example :
   spec:
     dataImage:
       url: http://1.2.3.4/image.iso
-      username: metal
-      password: password
-      insecure: false
+      credentialsName: dataimage-secret
+      disableCertificateVerification: false
+```
+
+Secret holding the image url credentials, base64 encoded :
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dataimage-secret
+type: Opaque
+data:
+  username: dGVzdA==
+  password: cGFzc3dvcmQ=
 ```
 
 Note that in this case, the iso image will be attached after the node
@@ -50,7 +67,30 @@ accepted by the upstream Ironic community.
 ## Design Details
 
 Add an optional section `DataImage` to `BareMetalHostSpec`, with sub-fields
-`Url`, `Username`, `Password`, `Insecure`.
+`Url`, `CredentialsName`, `DisableCertificateVerification` and a secret
+for dataImage with name `CredentialsName`.
+
+The ISO will be attached when the host is in either the `StateProvisioned` or
+the `StateExternallyProvisioned` state before `actionManageSteadyState` is
+called to maintain the State and manage the host power status.
+
+We want to attach the non-bootable ISO without an extra reboot.
+
+### Implementation Details
+
+**ToDo** : Explicitly and clearly define the order of actions for the
+below scenarios.
+
+What should be the order of action for attaching the ISO without an extra
+reboot(i.e attaching when the host is poweredoff), when :
+
+**Scenario 1** : `externallyProvisioned: true, online: true, dataImage: <set>`
+
+* Proposed workflow : "attach dataImage" -> ManageSteadyState
+
+**Scenario 2** : `image: <set>, online: true, dataImage: <set>`
+
+* Proposed workflow : "mount image" -> provision -> "provisioning finished"-> "detach image" -> "attach dataImage" ->  ManageSteadyState
 
 ## Dependencies
 

--- a/design/baremetal-operator/bmh_non-bootable_iso.md
+++ b/design/baremetal-operator/bmh_non-bootable_iso.md
@@ -35,7 +35,7 @@ drivers other than Redfish and its derived drivers.
 Add a new optional section in the BareMetalHost spec containing details of the
 non-bootable iso image, example :
 
-#### Current design
+#### Design spec
 
 ```yaml
   spec:
@@ -43,37 +43,21 @@ non-bootable iso image, example :
       url: http://1.2.3.4/image.iso
 ```
 
-#### Desired future design
-
-```yaml
-  spec:
-    dataImage:
-      url: http://1.2.3.4/image.iso
-      credentialsName: dataimage-secret
-      disableCertificateVerification: false
-```
-
-Secret holding the image url credentials, base64 encoded :
-
-```yaml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: dataimage-secret
-type: Opaque
-data:
-  username: dGVzdA==
-  password: cGFzc3dvcmQ=
-```
+We may consider adding support for HTTP credentials and TLS settings in the future
+but it's outside the scope of this proposal.
 
 **Note** : As part of this proposal, the dataImage will be attached after the node
 has been Provisioned or ExternallyProvisioned.
 
-### Ironic Proposal
+### Ironic Support
 
 The [proposal](https://bugs.launchpad.net/ironic/+bug/2033288) for exposing this functionaility in Ironic has been
 accepted by the upstream Ironic community.
+
+The [Ironic implementation](https://review.opendev.org/c/openstack/ironic/+/894918) based on the above proposalon has been completed.
+
+Other than that, we just need the implementation for driver specific support,
+which in this proposal is Redfish.
 
 ## Design Details
 
@@ -88,6 +72,12 @@ The `BareMetalHostStatus` will cache the image details, which will inform
 us if the attachment succeeded and will also be used for detachment, either
 when the attachment fails and we retry or when the user explicitly requests
 detachment by removing the `DataImage` spec from `BareMetalHost` object.
+
+A flag will be used at the webhook level to validate if a given driver supports the
+non-bootable ISO feature. Since the support for attaching an ISO as virtual media is
+equivalent for both `PreprovisioningISOImage` and `NonBootableISOImage`, we plan to
+rename the existing flag for `PreprovisioningISOImage` i.e. `SupportsISOPreprovisioningImage`
+to `SupportVirtualMediaISOImage` and use it for both the cases.
 
 ### Implementation Details
 


### PR DESCRIPTION
This proposal is for a new feature that allows for attaching a non-bootable iso image to a BMH after it has been provisioned.