### PR TITLE
fix new link in installation_guide.md

### DIFF
--- a/docs/user-guide/src/capm3/installation_guide.md
+++ b/docs/user-guide/src/capm3/installation_guide.md
@@ -12,7 +12,7 @@ install them yourself.
 1. Install `clusterctl`, refer to Cluster API [book](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl) for installation instructions.
 1. Install `kustomize`, refer to official instructions [here](https://kubectl.docs.kubernetes.io/installation/kustomize/).
 1. Install Ironic, refer to [this page](../ironic/ironic_installation.html).
-1. Install Baremetal Operator, refer to [TODO](TODO).
+1. Install Baremetal Operator, refer to [this page](https://github.com/metal3-io/baremetal-operator/blob/main/docs/dev-setup.md).
 1. Install Cluster API core compoenents i.e., core, bootstrap and control-plane providers. This will also install cert-manager, if it is not already installed.
 
     ```bash


### PR DESCRIPTION
A new link for an installation  guide on bare metal operators which can be found here https://github.com/metal3-io/baremetal-operator/blob/main/docs/dev-setup.md 