### PR TITLE
add clomonitor badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Metal³
 
+[![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/metal3-io/badge)](https://clomonitor.io/projects/cncf/metal3-io)
+
 ## What is Metal³
 
 The Metal³ project (pronounced: Metal Kubed) exists to provide components that


### PR DESCRIPTION
Add CLOMonitor badge to README as metal3-docs is one of the included repos that is checked.