### PR TITLE
update releasing.md

### DIFF
--- a/processes/releasing.md
+++ b/processes/releasing.md
@@ -10,33 +10,31 @@ Note the [TODO](#releasing-process-todo) section in the end.
 High-level release process for a major/minor release. For patch releases, only
 release the relevant versions.
 
+1. [Release ironic-image](https://github.com/metal3-io/ironic-image/blob/main/docs/releasing.md)
 1. [Release IPAM](https://github.com/metal3-io/ip-address-manager/blob/main/docs/releasing.md)
 1. [Release BMO](https://github.com/metal3-io/baremetal-operator/blob/main/docs/releasing.md)
 1. [Release CAPM3](https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/docs/releasing.md)
-1. [Tag Ironic and Mariadb images](#tag-ironic-and-mariadb-images)
+1. [Tag Mariadb image](#tag-mariadb-image)
 1. [Update Metal3 dev-env and CI to support new releases](#update-metal3-dev-env-and-ci-to-support-new-releases)
 
 **NOTE**: Always follow release documentation from the respective main branch.
 Release documentation in release branches may be outdated.
 
-## Tag Ironic and Mariadb images
+## Tag Mariadb image
 
 After releasing `v1.x.y` version of CAPM3, create an annotated tag with `capm3-`
 prefix + release version in
-[ironic-image](https://github.com/metal3-io/ironic-image) and
-[mariadb-image](https://github.com/metal3-io/mariadb-image) Github
-repositories.
+[mariadb-image](https://github.com/metal3-io/mariadb-image) Github repository.
 
 ```bash
 git tag -s -a capm3-v1.x.y -m capm3-v1.x.y [optional sha, or tag^{}]
 git push origin capm3-v1.x.y
 ```
 
-After this, [Ironic](https://quay.io/repository/metal3-io/ironic) and
-[MariaDB](https://quay.io/repository/metal3-io/mariadb) container images will
-be built automatically  with `capm3-v1.x.y` tag in Quay. Verify the build is
-triggered, as often Quay has disabled the build trigger due build failures or
-other reasons.
+After this, [MariaDB](https://quay.io/repository/metal3-io/mariadb) container
+image will be built automatically  with `capm3-v1.x.y` tag in Quay. Verify the
+build is triggered, as often Quay has disabled the build trigger due build
+failures or other reasons.
 
 ## Update Metal3 dev-env and CI to support new releases
 
@@ -126,31 +124,15 @@ Thanks to all our contributors! :blush:
 
 ### BMO
 
-BMO releasing to be implemented.
+BMO releasing to be fine-tuned.
 
-1. BMO releasing and maintenance
-   - BMO does not have release branches, only tags off the `main` branch
-   - Without release branches, maintaining BMO versions that are coupled with
-     CAPM3 releases is impossible
-   - [BMO release documentation](https://github.com/metal3-io/baremetal-operator/blob/main/docs/releasing.md)
-     is already up to date for releasing from branches, but BMO CI needs to be
-     decoupled from CAPM3 CI, and BMO end-to-end testing implemented to support
-     release branches.
-     [Proposal PR here](https://github.com/metal3-io/metal3-docs/pull/345).
 1. BMO dependencies
    - BMO contains `keepalived`
      ([within BMO repo](https://github.com/metal3-io/baremetal-operator/tree/main/resources/keepalived-docker))
-1. BMO makes strong assumption about the exact configuration of Ironic.
-   However, [ironic-image](https://github.com/metal3-io/ironic-image) is
-   currently branchless.
 1. BMO makes assumption about the exact configuration of MariaDB.
    However, [mariadb-image](https://github.com/metal3-io/mariadb-image) is
    currently branchless.
 
-### Ironic-image
-
-Ironic-image releasing to be implemented. Largely same issues as BMO.
-
 ### Mariadb-image
 
-Mariadb-image releasing to be implemented. Largely same issues as BMO.
+Mariadb-image releasing to be implemented.


### PR DESCRIPTION
We have made good progress on the releasing side. We have ironic-image releases now, as well as BMO is properly branched and released. Add relevant links to those documents, remove some of the TODO etc.