### PR TITLE
✨ Added placeholders that resolve to the latest version tag of a release

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -68,4 +68,12 @@ Before submitting document change, you can run the same mdbook binary to preview
     ```
 
 You should have the user-guide available now at `localhost:3000`.
-Also, the serve command watches the `src` directory for changes and rebuilds the user-guide for every change.
+Also, the serve command watches the `src` directory for changes and rebuilds theuser-guide for every change.
+
+## Dynamic Version Numbers
+
+Some version numbers are automatically generated. This is done with JavaScript
+after the page is rendered.
+{releaselink:repo:<https://api.github.com/repos/metal3-io/cluster-api-provider-metal3>:stable:any}
+Stable variable can be: any, stable or prerelease. If not set a stable release
+tag will be fetched.

--- a/docs/user-guide/book.toml
+++ b/docs/user-guide/book.toml
@@ -8,3 +8,4 @@ title = "Metal³ user-guide"
 [output.html]
 git-repository-url = "https://github.com/metal3-io/"
 curly-quotes = true
+additional-js = ["release_version.js"]

--- a/docs/user-guide/release_version.js
+++ b/docs/user-guide/release_version.js
@@ -1,0 +1,61 @@
+async function getMatch(match) {
+    // Check if the match is already in the session storage
+    let version = sessionStorage.getItem(`${match[0]}`);
+    let version_tag;
+
+    if (version) {
+        // If it is, parse it and use it
+        version_tag = JSON.parse(version);
+    } else {
+        const repo = match[1];
+        const stable = match[3];
+
+        version_tag = await getReleaseLink(repo, stable);
+        sessionStorage.setItem(match[0], JSON.stringify(version_tag));
+        console.log("Fetching version tag from GitHub");
+    }
+
+    return version_tag;
+}
+
+// Function to fetch the latest release tag name from a GitHub repository
+async function getReleaseLink(repo, stable="stable") {
+    const response = await fetch(`${repo}/releases`);
+    let releases = await response.json();
+    
+    switch (stable) {
+        case "any":
+            break;
+        case "stable":
+            releases = releases.filter(release => !release.prerelease);
+            break;
+        case "prerelease":
+            releases = releases.filter(release => release.prerelease);
+            break;
+    }
+
+    return releases[0].tag_name;
+    
+}
+
+async function replacePlaceholders() {
+    // Regular expression to match the placeholders
+    // and parse the api url to get the tag name
+    const regex = /\{releaselink:repo:(.*?)(:stable:(.*?))?\}/g;
+    html = document.body.innerHTML;
+    const matches = [...html.matchAll(regex)];
+
+
+    // Loop through the matches and replace the placeholders
+    // with the tag name in the HTML
+    for (const match of matches) {
+        const tagName = await getMatch(match);
+        if (tagName === undefined) {
+            continue;
+        }
+        html = html.replace(match[0], tagName);
+    }
+
+    document.body.innerHTML = html;
+}
+replacePlaceholders();

--- a/docs/user-guide/src/baremetal/guide.md
+++ b/docs/user-guide/src/baremetal/guide.md
@@ -116,7 +116,7 @@ Install following requirements on the host.
   ```bash
   kubectl create namespace metal3
   clusterctl init --core cluster-api --bootstrap kubeadm --control-plane kubeadm --infrastructure metal3
-  # NOTE: In clusterctl init you can change the version of provider like this "cluster-api:v1.6.0",
+  # NOTE: In clusterctl init you can change the version of provider like this "{releaselink:repo:https://api.github.com/repos/kubernetes-sigs/cluster-api}",
   # if no version is given by deafult latest stable release will be used.
   ```
 

--- a/docs/user-guide/src/capm3/installation_guide.md
+++ b/docs/user-guide/src/capm3/installation_guide.md
@@ -16,16 +16,16 @@ install them yourself.
 1. Install Cluster API core compoenents i.e., core, bootstrap and control-plane providers. This will also install cert-manager, if it is not already installed.
 
     ```bash
-     clusterctl init --core cluster-api:v1.1.4 --bootstrap kubeadm:v1.1.4 \
-     --control-plane kubeadm:v1.1.4 -v5
+     clusterctl init --core cluster-api:{releaselink:repo:https://api.github.com/repos/kubernetes-sigs/cluster-api} --bootstrap kubeadm:{releaselink:repo:https://api.github.com/repos/kubernetes/kubernetes} \
+     --control-plane kubeadm:{releaselink:repo:https://api.github.com/repos/kubernetes/kubernetes} -v5
     ```
 
 ## With clusterctl
 
-This method is recommended. You can specify the CAPM3 version you want to install by appending a version tag, e.g. `:v1.1.2`. If the version is not specified, the latest version available will be installed.
+This method is recommended. You can specify the CAPM3 version you want to install by appending a version tag, e.g. `{releaselink:repo:https://api.github.com/repos/metal3-io/cluster-api-provider-metal3}`. If the version is not specified, the latest version available will be installed.
 
 ```bash
-clusterctl init --infrastructure metal3:v1.1.2
+clusterctl init --infrastructure metal3:{releaselink:repo:https://api.github.com/repos/metal3-io/cluster-api-provider-metal3}
 ```
 
 ## With kustomize

--- a/docs/user-guide/src/capm3/pivoting.md
+++ b/docs/user-guide/src/capm3/pivoting.md
@@ -127,9 +127,11 @@ This can now be achieved with the following procedure:
    Example:
 
    ```bash
-   clusterctl init --infrastructure metal3:v1.1.0
+   clusterctl init --infrastructure metal3:{releaselink:repo:https://api.github.com/repos/metal3-io/cluster-api-provider-metal3}
    --target-namespace metal3 --watching-namespace metal3
    ```
+
+   NOTE: In clusterctl init you can change the version of provider by appending a version tag, if no version is given by deafult latest stable release will be used.
 
    This command will create the necessary CAPI controllers (CAPI, CABPK, CAKCP)
    and CAPM3 as the infrastructure provider. All of the controllers will be installed
@@ -155,9 +157,11 @@ This can now be achieved with the following procedure:
     Example:
 
     ```bash
-    clusterctl init --kubeconfig target.yaml --infrastructure metal3:v1.1.0
+    clusterctl init --kubeconfig target.yaml --infrastructure metal3:{releaselink:repo:https://api.github.com/repos/metal3-io/cluster-api-provider-metal3}
     --target-namespace metal3 --watching-namespace metal3
     ```
+
+   NOTE: In clusterctl init you can change the version of provider by appending a version tag, e.g. "metal3:{releaselink:repo:<https://api.github.com/repos/metal3-io/cluster-api-provider-metal3>}", if no version is given by deafult latest stable release will be used.
 
 8. Use `clusterctl` move to move the Cluster API resources from the bootstrap
  cluster to the target management cluster.

--- a/docs/user-guide/src/introduction.md
+++ b/docs/user-guide/src/introduction.md
@@ -60,3 +60,10 @@ Guide](https://metal3.io/try-it.html)). Nor is it a reference (for that, see
 the [API Reference
 Documentation](https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/docs/api.md),
 and of course, the code itself.)
+
+NOTE: In this book some version numbers are dynamically generated. This is done
+with JavaScript after rendering the page. If You are seing placeholder text like
+this '{releaselink:repo:api-url-ro-get-version}', this is propably due to your
+browser having JavaScript turned off. This can be fixed by turning JavaScript
+on or you can just remove the placeholder and replace it with a stable version
+or leave the version number out when the lates stable version will be used.  


### PR DESCRIPTION
Added placeholders that will be resolved in the latest version tag of the given project. Version numbers are resolved after the page is rendered with JavaScript. 

Known issue: User will see placeholders if JavaScript is disabled in browser.