### PR TITLE
:sparkles:  Go preprocessor to find and replace releasetags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,20 @@ HOST_PORT ?= 3000
 BIN_DIR := hack
 MDBOOK_BIN := $(BIN_DIR)/mdbook
 MDBOOK_RELEASE_URL := https://github.com/rust-lang/mdBook/releases/download/$(MDBOOK_BIN_VERSION)/mdbook-$(MDBOOK_BIN_VERSION)-x86_64-unknown-linux-gnu.tar.gz
+TOOLS_DIR := hack/tools
+TOOLS_BIN_DIR := $(abspath $(TOOLS_DIR)/bin)
+
+export PATH := $(PATH):$(TOOLS_BIN_DIR)
+
+## ------------------------------------
+## Resolve placeholders as tags
+## ------------------------------------
+RELEASETAGS := $(TOOLS_BIN_DIR)/mdbook-releasetags
+$(RELEASETAGS): $(TOOLS_DIR)/go.mod
+	cd $(TOOLS_DIR); go build -tags=tools -o $(TOOLS_BIN_DIR)/mdbook-releasetags ./releasetags
+
+.PHONY: releasetags
+releasetags: $(RELEASETAGS)
 
 ## ------------------------------------
 ## Documentation tooling for Netlify
@@ -19,7 +33,7 @@ $(MDBOOK_BIN): # Download the binary
 	curl -L $(MDBOOK_RELEASE_URL) | tar xvz -C $(BIN_DIR)
 
 .PHONY: netlify-build
-netlify-build: $(MDBOOK_BIN) # Build the user guide
+netlify-build: $(RELEASETAGS) $(MDBOOK_BIN) # Build the user guide
 	$(MDBOOK_BIN) build $(SOURCE_PATH)
 
 
@@ -28,7 +42,8 @@ netlify-build: $(MDBOOK_BIN) # Build the user guide
 ## ------------------------------------
 
 .PHONY: build
-build: # Build the user guide
+build: $(RELEASETAGS)
+# Build the user guide
 	$(CONTAINER_RUNTIME) run \
 	--rm -it --name metal3 \
 	-v "$$(pwd):/workdir" \
@@ -36,13 +51,14 @@ build: # Build the user guide
 	mdbook build $(SOURCE_PATH)
 
 .PHONY: serve
-serve: # Serve the user-guide on localhost:3000 (by default)
+serve: $(RELEASETAGS)
+# Serve the user-guide on localhost:3000 (by default)
 	$(CONTAINER_RUNTIME) run \
 	--rm -it --init --name metal3 \
 	-v "$$(pwd):/workdir" \
 	-p $(HOST_PORT):3000 \
 	$(IMAGE_NAME):$(IMAGE_TAG) \
-	mdbook serve --open $(SOURCE_PATH) -p 3000 -n 0.0.0.0
+	mdbook serve --open $(SOURCE_PATH) -p 3000 -n 0.0.0.0 
 
 .PHONY: clean
 clean: # Clean mdbook generated content

--- a/docs/user-guide/book.toml
+++ b/docs/user-guide/book.toml
@@ -8,3 +8,7 @@ title = "Metal³ user-guide"
 [output.html]
 git-repository-url = "https://github.com/metal3-io/"
 curly-quotes = true
+
+[preprocessor.releasetags]
+command = "mdbook-releasetags"
+renderers = ["html"]

--- a/docs/user-guide/src/capm3/installation_guide.md
+++ b/docs/user-guide/src/capm3/installation_guide.md
@@ -22,10 +22,10 @@ install them yourself.
 
 ## With clusterctl
 
-This method is recommended. You can specify the CAPM3 version you want to install by appending a version tag, e.g. `:v1.1.2`. If the version is not specified, the latest version available will be installed.
+This method is recommended. You can specify the CAPM3 version you want to install by appending a version tag, e.g. `:{{#releasetag repo:"repo-url-here"}}`. If the version is not specified, the latest version available will be installed.
 
 ```bash
-clusterctl init --infrastructure metal3:v1.1.2
+clusterctl init --infrastructure metal3:{{#releasetag repo:"repo-url-here"}}
 ```
 
 ## With kustomize

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,0 +1,5 @@
+module metal3-io/metal3-docs/hack/tools
+
+go 1.22.0
+
+require sigs.k8s.io/kubebuilder/docs/book/utils v0.0.0-20240216033807-8afeb403549f

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -1,0 +1,2 @@
+sigs.k8s.io/kubebuilder/docs/book/utils v0.0.0-20240216033807-8afeb403549f h1:0rbnCuTF/IIxfwoJR/p7zTB5+AA0RaBwB0lqjBUs/28=
+sigs.k8s.io/kubebuilder/docs/book/utils v0.0.0-20240216033807-8afeb403549f/go.mod h1:4CGoZGcqb7Bes5d0qgb4SIHqk+XjUfoxesbbTmpVl6s=

--- a/hack/tools/releasetags/releasetags.go
+++ b/hack/tools/releasetags/releasetags.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"reflect"
+	"strings"
+
+	"sigs.k8s.io/kubebuilder/docs/book/utils/plugin"
+)
+
+type ReleaseTag struct{}
+
+// SupportsOutput checks if the given plugin supports the given output format.
+func (ReleaseTag) SupportsOutput(_ string) bool { return true }
+
+// Process modifies the book in the input, which gets returned as the result of the plugin.
+func (l ReleaseTag) Process(input *plugin.Input) error {
+	return plugin.EachCommand(&input.Book, "releasetag", func(chapter *plugin.BookChapter, args string) (string, error) {
+		var repo string
+		var found bool
+
+		tags := reflect.StructTag(strings.TrimSpace(args))
+
+		if repo, found = tags.Lookup("repo"); !found {
+			return "", fmt.Errorf("releasetag requires tag \"repo\" to be set")
+		}
+
+		// Replace the content of the chapter with a JSON object
+		replacedContent := map[string]string{
+			"content": fmt.Sprintf("REPLACED_CONTENT_%s", repo),
+		}
+		replacedContentJSON, err := json.Marshal(replacedContent)
+		if err != nil {
+			return "", err
+		}
+
+		return string(replacedContentJSON), nil
+	})
+}
+
+func main() {
+	cfg := ReleaseTag{}
+
+	// Read input from os.Stdin
+	input, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Write input to input.log
+	err = os.WriteFile("input.log", input, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a bytes buffer to capture the output
+	var output bytes.Buffer
+
+	// Run the preprocessor
+	if err := plugin.Run(cfg, bytes.NewReader(input), &output, os.Args[1:]...); err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// Write output to output.log
+	err = os.WriteFile("output.log", output.Bytes(), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This is a mdbook preprocessor writen in go. The go method uses a [plugin](https://github.com/kubernetes-sigs/kubebuilder/tree/master/docs/book/utils/plugin) to find tags and replace them.  [Cluster-api documentation has implemented](https://github.com/kubernetes-sigs/cluster-api/blob/main/hack/tools/mdbook/releaselink/releaselink.go#L49) this plugin and I'm trying to use the plugin in the same way except for minor changes to fit the metal3 use case better. 