### PR TITLE
Add baremetal-operator image version in kustomization.yaml example

### DIFF
--- a/docs/user-guide/src/quick-start.md
+++ b/docs/user-guide/src/quick-start.md
@@ -554,6 +554,9 @@ namespace: baremetal-operator-system
 # Note that the ref=v0.5.1 specifies the version to use.
 resources:
 - https://github.com/metal3-io/baremetal-operator/config/overlays/basic-auth_tls?ref=v0.5.1
+images:
+- name: quay.io/metal3-io/baremetal-operator
+  newTag: v0.5.1
 # Create a ConfigMap from ironic.env and name it ironic.
 configMapGenerator:
 - name: ironic


### PR DESCRIPTION
Error:
```
"msg":"if kind is a CRD, it should be installed before calling Start","kind":"HostFirmwareComponents.metal3.io","error":"no matches for kind \"HostFirmwareComponents\" in version \"metal3.io/v1alpha1\""
```
Related to #395