### PR TITLE
hack/tools: reduce required Go version

### DIFF
--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module metal3-io/metal3-docs/hack/tools
 
-go 1.22
+go 1.21
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
1.22 is very new and is not yet available in most distributions.
It seems that 1.21 works fine.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
