### PR TITLE
Bump rust to v0.4.37

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MDBOOK_BIN_VERSION ?= v0.4.15
+MDBOOK_BIN_VERSION ?= v0.4.37
 SOURCE_PATH := docs/user-guide
 CONTAINER_RUNTIME ?= sudo docker
 IMAGE_NAME := quay.io/metal3-io/mdbook

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,6 @@
 [build]
     command = "make netlify-build"
     publish = "docs/user-guide/book"
+
+[build.environment]
+    GO_VERSION = "1.22.2"


### PR DESCRIPTION
Rust v0.4.15 is pretty old and we had several versions out since then. Also add GO_VERSION var in the netlify build config. We set it previously in netlify build settings web ui, however setting it explicitly here is more easier and doesn't require special permission for the webui. 