### PR TITLE
Merge API references and fix empty link

### DIFF
--- a/docs/user-guide/src/SUMMARY.md
+++ b/docs/user-guide/src/SUMMARY.md
@@ -33,7 +33,4 @@
 - [Try it (for developers)](developer_environment/tryit.md)
 - [Version Support](version_support.md)
 - [Project Security Policy](security_policy.md)
-- [Refernce]()
-   - [Baremetal Operator Reference](reference/bmo.md)
-   - [Cluster API provider Refernce](reference/capm3.md)
-   - [Ip Addresss Manager Reference](reference/ipam.md)
+- [API Reference](reference.md)

--- a/docs/user-guide/src/reference.md
+++ b/docs/user-guide/src/reference.md
@@ -1,0 +1,16 @@
+# API reference
+
+## Bare Metal Operator
+
+- Baremetal Operator (CRDs): [documentation](https://doc.crds.dev/github.com/metal3-io/baremetal-operator)
+- golang API documentation: [godoc](https://pkg.go.dev/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1)
+
+## Cluster API provider Metal3
+
+- Cluster API provider Metal3 (CRDs): [documentation](https://doc.crds.dev/github.com/metal3-io/cluster-api-provider-metal3)
+- golang API documentation: [godoc](https://pkg.go.dev/github.com/metal3-io/cluster-api-provider-metal3)
+
+## Ip Address Manager
+
+- Ip Address Manager (CRDs): [documentation](https://doc.crds.dev/github.com/metal3-io/ip-address-manager)
+- golang API documentation: [godoc](https://pkg.go.dev/github.com/metal3-io/ip-address-manager/api/v1alpha1)

--- a/docs/user-guide/src/reference/bmo.md
+++ b/docs/user-guide/src/reference/bmo.md
@@ -1,4 +1,0 @@
-# Bare Metal Operator Reference
-
-- Baremetal Operator (CRDs): [documentation](https://doc.crds.dev/github.com/metal3-io/baremetal-operator@v0.5.1)
-- golang API documentation: [godoc](https://pkg.go.dev/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1)

--- a/docs/user-guide/src/reference/capm3.md
+++ b/docs/user-guide/src/reference/capm3.md
@@ -1,4 +1,0 @@
-# Cluster API provider Metal3 Reference
-
-- Cluster API provider Metal3 (CRDs): [documentation](https://doc.crds.dev/github.com/metal3-io/cluster-api-provider-metal3)
-- golang API documentation: [godoc](https://pkg.go.dev/github.com/metal3-io/cluster-api-provider-metal3)

--- a/docs/user-guide/src/reference/ipam.md
+++ b/docs/user-guide/src/reference/ipam.md
@@ -1,4 +1,0 @@
-# Ip Address Manager Reference
-
-- Ip Address Manager (CRDs): [documentation](https://doc.crds.dev/github.com/metal3-io/ip-address-manager)
-- golang API documentation: [godoc](https://pkg.go.dev/github.com/metal3-io/ip-address-manager/api/v1alpha1)


### PR DESCRIPTION
This merges the API references for BMO CAPM3 and IPAM into one single page. It also fixes an issue with an empty link in the TOC that was causing the mdbook preprocessor to fail.