### PR TITLE
:seedling: Add warning about links without a path

### DIFF
--- a/docs/user-guide/src/SUMMARY.md
+++ b/docs/user-guide/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Metal3 Project
 
-<!-- markdownlint-disable no-empty-links -->
+[comment]: After adding the releasetag preprocessor the build fails with output "thread 'main' panicked at '', src/utils/fs.rs:45:10" if there are links with empty paths.
 
 [Introduction](introduction.md)
 


### PR DESCRIPTION
To avoid future confusion: add a warning about empty links and add empty link check back. 
There is an open issue about this now with mdbook: https://github.com/rust-lang/mdBook/issues/2369