### PR TITLE
Add docker-build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ design/*.toc.*
 
 # Ignore all binaries
 # from being committed.
-hack/tools/
+hack/tools/bin
 # Ignore mdbook boilerplate
 # from being committed.
 docs/user-guide/book

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-MDBOOK_BIN_VERSION ?= v0.4.37
+MDBOOK_VERSION ?= 0.4.37
+MDBOOK_BIN_VERSION ?= v$(MDBOOK_VERSION)
 SOURCE_PATH := docs/user-guide
 CONTAINER_RUNTIME ?= sudo docker
 IMAGE_NAME := quay.io/metal3-io/mdbook
@@ -39,6 +40,11 @@ netlify-build: $(RELEASETAGS) $(MDBOOK_BIN)
 ## ------------------------------------
 ## Documentation tooling for local dev
 ## ------------------------------------
+
+.PHONY: build
+docker-build: # Build the mdbook container image
+	$(CONTAINER_RUNTIME) build --build-arg MDBOOK_VERSION=$(MDBOOK_VERSION) \
+	--tag $(IMAGE_NAME):$(IMAGE_TAG) -f docs/Dockerfile .
 
 .PHONY: build
 build:# Build the user guide

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,31 @@
-FROM rust:1.69.0-slim@sha256:8b85a8a6bf7ed968e24bab2eae6f390d2c9c8dbed791d3547fef584000f48f9e
-ARG MDBOOK_BIN_VERSION="0.4.15"
-RUN cargo install mdbook --vers ${MDBOOK_BIN_VERSION}
+ARG BUILD_IMAGE=docker.io/golang:1.21.9@sha256:7d0dcbe5807b1ad7272a598fbf9d7af15b5e2bed4fd6c4c2b5b3684df0b317dd
+FROM $BUILD_IMAGE as builder
+WORKDIR /workspace
+
+# Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
+ARG goproxy=https://proxy.golang.org
+ENV GOPROXY=$goproxy
+
+# Copy the Go Modules manifests
+COPY hack/tools/go.mod go.mod
+COPY hack/tools/go.sum go.sum
+
+# Cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the sources
+COPY hack/tools/releasetags/ releasetags/
+
+# Build
+ARG ARCH=amd64
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
+  go build -tags=tools -a -ldflags '-extldflags "-static"' \
+  -o mdbook-releasetags ./releasetags
+
+FROM rust:1.78.0-slim@sha256:517c6272b328bc51c87e099ef4adfbc7ab4558af2d757e8d423c7c3f1cbbf9d5
+ARG MDBOOK_VERSION="0.4.37"
+RUN cargo install mdbook --vers ${MDBOOK_VERSION}
 RUN cp /usr/local/cargo/bin/mdbook /usr/bin/mdbook
+COPY --from=builder /workspace/mdbook-releasetags /usr/bin/mdbook-releasetags
 WORKDIR /workdir


### PR DESCRIPTION
This adds a docker-build make target for building the container image. The Dockerfile is also expanded to build the releasetags preprocessor in a build container instead of copying from the host.

The mdbook version is taken from the Makfile as an argument. The rust version is bumped since the old version could not build the newer mdbook version. (The versions in the Dockerfile and Makefile were different.)