### PR TITLE
User guide: migrate BMC addressing information from BMO

### DIFF
--- a/docs/user-guide/src/SUMMARY.md
+++ b/docs/user-guide/src/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Installing on Baremetal](baremetal/guide.md)
 - [Baremetal Operator](bmo/introduction.md)
    - [Install Baremetal Operator](bmo/install_baremetal_operator.md)
+   - [Supported Hardware](bmo/supported_hardware.md)
    - [Features](bmo/features.md)
       - [Automated Cleaning](bmo/automated_cleaning.md)
       - [Automatic Secure Boot](bmo/automatic_secure_boot.md)

--- a/docs/user-guide/src/baremetal/guide.md
+++ b/docs/user-guide/src/baremetal/guide.md
@@ -10,23 +10,14 @@ This is a separate machine, e.g. your laptop or one of the servers, that has acc
 
 ## Install requirements on the host
 
-Login to the host from where you want to provision. The baremetal nodes should be accesible from the host via one of the following protocols.
-
-- IPMI
-- Redfish
-- WSMAN
-- iRMC
-- ibmc
-- iLO
-
-See [Install Ironic](../ironic/ironic_installation.md) for other requirements.
-
-Install following requirements on the host.
+Install following requirements on the host:
 
 - Python
 - Golang
 - Docker for ubuntu and podman for Centos
 - Ansible
+
+See [Install Ironic](../ironic/ironic_installation.md) for other requirements.
 
 ## Configure host
 

--- a/docs/user-guide/src/bmo/introduction.md
+++ b/docs/user-guide/src/bmo/introduction.md
@@ -25,6 +25,7 @@ the following properties:
 1. The IP address and credentials of the BMC - the remote management controller
    of the host.
 2. The protocol that the BMC understands. Most common are IPMI and Redfish.
+   See [supported hardware](supported_hardware) for more details.
 3. Boot technology that can be used with the host and the chosen protocol.
    Most hardware can use network booting, but some Redfish implementations also
    support virtual media (CD) boot.

--- a/docs/user-guide/src/bmo/supported_hardware.md
+++ b/docs/user-guide/src/bmo/supported_hardware.md
@@ -1,0 +1,97 @@
+# Supported hardware
+
+Metal3 supports many vendors and models of enterprise-grade hardware with
+a *BMC* ([Baseboard Management Controller][bmc]) that supports one of the
+remote management protocols described in this document. On top of that, one of
+the two boot methods must be supported:
+
+1. Network boot. Most hardware supports booting a Linux kernel and initramfs
+   via TFTP. Metal3 augments it with [iPXE][ipxe] - a higher level network boot
+   firmware with support for scripting and TCP-based protocols such as HTTP.
+
+   Booting over network relies on DHCP and thus requires a *provisioning
+   network* for isolated L2 traffic between the Metal3 control plane and the
+   machines.
+
+2. Virtual media boot. Some hardware model support directly booting an ISO 9660
+   image as a virtual CD device over HTTP(s). An important benefit of this
+   approach is the ability to boot hardware over L3 networks, potentially
+   without DHCP at all.
+
+## IPMI
+
+[IPMI][ipmi] is the oldest and by far the most widely available remote
+management protocol. Nearly all enterprise-grade hardware supports it. Its
+downside include reduced reliability and a weak security, especially if not
+configured properly.
+
+**WARNING:** only network boot over iPXE is supported for IPMI.
+
+<!-- markdownlint-disable MD013 -->
+
+| BMC address format     | Notes                                   |
+|------------------------|-----------------------------------------|
+| `ipmi://<host>:<port>` | Port is optional, defaults to 623.      |
+| `<host>:<port>`        | IPMI is the default protocol in Metal3. |
+
+<!-- markdownlint-enable MD013 -->
+
+## Redfish and its variants
+
+[Redfish][redfish] is a vendor-agnostic protocol for remote hardware
+management. It is based on HTTP(s) and JSON and thus does not suffer from the
+limitations of IPMI. It also exposes modern features such as virtual media
+boot, RAID management, firmware settings and updates.
+
+Ironic (and thus Metal3) aims to support Redfish as closely to the standard as
+possible, with a few workarounds for known issues and explicit support for Dell
+iDRAC. Note, however, that all features are optional in Redfish, so you may
+encounter a Redfish-capable hardware that is not supported by Metal3.
+Furthermore, some features (such as virtual media boot) may require buying an
+additional license to function.
+
+Since a Redfish API endpoint can manage several servers (*systems* in Redfish
+terminology), BMC addresses for Redfish-based drivers include a *system ID* -
+the URL of the particular server. For Dell machines it usually looks like
+`/redfish/v1/Systems/System.Embedded.1`, while other vendors may simply use
+`/redfish/v1/Systems/1`. Check the hardware documentation to find out which
+format is right for your machine.
+
+<!-- markdownlint-disable MD013 -->
+
+| Technology      | Boot method   | BMC address format                                | Notes                                                                   |
+|-----------------|---------------|---------------------------------------------------|-------------------------------------------------------------------------|
+| Generic Redfish | iPXE          | `redfish://<host>:<port>/<systemID>`              |                                                                         |
+|                 | Virtual media | `redfish-virtualmedia://<host>:<port>/<systemID>` | **Must not** be used for Dell machines.                                 |
+| Dell iDRAC 8+   | iPXE          | `idrac-redfish://<host>:<port>/<systemID>`        |                                                                         |
+|                 | Virtual media | `idrac-virtualmedia://<host>:<port>/<systemID>`   | Requires firmware v6.10.30.00+ for iDRAC 9, v2.75.75.75+ for iDRAC 8.   |
+| HPE iLO 5 and 6 | iPXE          | `ilo5-redfish://<host>:<port>/<systemID>`         | An alias of `redfish` for convenience. RAID management only on iLO 6.   |
+|                 | Virtual media | `ilo5-virtualmedia://<host>:<port>/<systemID>`    | An alias of `redfish` for convenience. RAID management only on iLO 6.   |
+
+<!-- markdownlint-enable MD013 -->
+
+Users have also reported success with certain models of SuperMicro, Lenovo, ZT
+Systems and Cisco UCS hardware, but hardware from these vendors is not
+regularly tested by the team.
+
+All drivers based on Redfish allow optionally specifying the carrier protocol
+in the form of `+http` or `+https`, for example: `redfish+http://...` or
+`idrac-virtualmedia+https`. When not specified, HTTPS is used by default.
+
+## Vendor-specific protocols
+
+<!-- markdownlint-disable MD013 -->
+
+| Technology      | Protocol | Boot method   | BMC address format                  | Notes                                                                   |
+|-----------------|----------|---------------|-------------------------------------|-------------------------------------------------------------------------|
+| Fujitsu iRMC    | iRMC     | iPXE          | `irmc://<host>:<port>`              | Port is optional, the default is 443.                                   |
+| HPE iLO 4       | iLO      | iPXE          | `ilo4://<host>:<port>`              | Port is optional, the default is 443.                                   |
+|                 | iLO      | Virtual media | `ilo4-virtualmedia://<host>:<port>` |                                                                         |
+| HPE iLO 5       | iLO      | iPXE          | `ilo5://<host>:<port>`              | Should only be used instead of Redfish if you need RAID support.        |
+
+<!-- markdownlint-enable MD013 -->
+
+[bmc]: https://en.wikipedia.org/wiki/Intelligent_Platform_Management_Interface#Baseboard_management_controller
+[ipxe]: https://ipxe.org/
+[ipmi]: https://en.wikipedia.org/wiki/Intelligent_Platform_Management_Interface
+[redfish]: https://redfish.dmtf.org/

--- a/docs/user-guide/src/quick-start.md
+++ b/docs/user-guide/src/quick-start.md
@@ -680,7 +680,8 @@ file as the secret if you want. Just remember to separate the two resources with
 one line containing `---`.
 
 Here is an example of a BareMetalHost referencing the secret above with MAC
-address and BMC address matching our `bml-01` server.
+address and BMC address matching our `bml-01` server (see [supported
+hardware](bmo/supported_hardware) for information on BMC addressing).
 
 ```yaml
 apiVersion: metal3.io/v1alpha1


### PR DESCRIPTION
Adds a new page "Supported hardware" with information loosely based on
the BMO docs with these modifications:
- Split one large table into sections based on the underlying
  technology.
- Copy supported Dell firmware versions from OpenShift docs.
- Write clarifications on Redfish support status.
- Highlight supporting iLO 6.
- Highlight which iLO 5 drivers support hardware RAID.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
