### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,20 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- dtantsur
-- kashifest
-- lentzi90
-- zaneb
+- metal3-docs-maintainers
 
 reviewers:
-- adilGhaffarDev
-- hroyrh
-- mboukhalfa
-- Rozzii
-- smoshiur1237
-- s3rj1k
-- tuminoid
-- zhouhao3
+- metal3-docs-maintainers
+- metal3-docs-reviewers
 
 emeritus_approvers:
 - andfasano

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,30 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  # root
+  metal3-docs-maintainers:
+  - dtantsur
+  - kashifest
+  - lentzi90
+  - zaneb
+
+  metal3-docs-reviewers:
+  - adilGhaffarDev
+  - hroyrh
+  - mboukhalfa
+  - Rozzii
+  - smoshiur1237
+  - s3rj1k
+  - tuminoid
+  - zhouhao3
+
+  # design
+  metal3-docs-design-maintainers:
+  - dtantsur
+  - kashifest
+  - Rozzii
+  - zaneb
+
+  metal3-docs-design-reviewers:
+  - elfosardo
+  - lentzi90

--- a/design/OWNERS
+++ b/design/OWNERS
@@ -1,22 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
- - dtantsur
- - kashifest
- - Rozzii
- - zaneb
+- metal3-docs-design-maintainers
 
 reviewers:
- - elfosardo
- - lentzi90
+- metal3-docs-design-maintainers
+- metal3-docs-design-reviewers
 
 emeritus_approvers:
- - andfasano
- - fmuyassarov
- - furkatgofurov7
- - hardys
- - maelk
- - russellb
+- andfasano
+- fmuyassarov
+- furkatgofurov7
+- hardys
+- maelk
+- russellb
 
 options:
   no_parent_owners: true


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.