### PR TITLE
fix broken link to a kubelet kep

### DIFF
--- a/design/sync-labels-bmh-to-node.md
+++ b/design/sync-labels-bmh-to-node.md
@@ -244,7 +244,7 @@ this label.
 
 There is also a security vulnerability associated with kubelet's ability to
 self-label the Node object. This has been
-[addressed](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/0000-20170814-bounding-self-labeling-kubelets.md).
+[addressed](https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/279-limit-node-access).
 However, as a consequence, BMH labels that fall within the *.kubernetes.io/*
 space cannot be specified via kubelet's `--node-labels` flag.
 


### PR DESCRIPTION
Fix broken link to a kubelet KEP.

Supersedes: #356 as it is abandoned.