### PR TITLE
:seedling: Add ironic release-26.0 to the version support

### DIFF
--- a/docs/user-guide/src/version_support.md
+++ b/docs/user-guide/src/version_support.md
@@ -63,17 +63,18 @@ Following table summarizes BMO release/test process:
 ## Ironic-image
 
 Since `v23.1.0`, Ironic follows the semantic versioning scheme for its own
-release cycle, the same way as CAPM3 and IPAM. Currently, we have release-25.0,
-release-24.1, release-24.0 and release-23.1 release branches for `v25.0.x`,
-`v24.1.x` `v24.0.x` and `v23.1.x` release cycle respectively and as such two or
-three braches are maintained as supported releases.
+release cycle, the same way as CAPM3 and IPAM. Currently, we have release-26.0,
+release-25.0, release-24.1, release-24.0 and release-23.1 release branches for
+`v26.0.x`, `v25.0.x`, `v24.1.x` `v24.0.x` and `v23.1.x` release cycle respectively
+and as such two or three braches are maintained as supported releases.
 Following table summarizes Ironic-image release/test process:
 
 | Minor release | Status    |
 | ------------- | --------- |
+| v26.0         | Supported |
 | v25.0         | Supported |
-| v24.1         | Supported |
-| v24.0         | Tested    |
+| v24.1         | Tested    |
+| v24.0         | EOL       |
 | v23.1         | EOL       |
 
 ## Image tags
@@ -105,7 +106,7 @@ The table describes which branches/image-tags are tested in each periodic CI tes
 | -------------------------------------------------------------- | ------------ | ----------- | -------------- | -------------- | ----------- | ---------- |
 | metal3-periodic-ubuntu/centos-e2e-integration-test-main        | main         | main        | main           | latest         | latest      | latest     |
 | metal3_periodic_main_integration_test_ubuntu/centos            | main         | main        | main           | latest         | latest      | latest     |
-| metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-8 | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v25.0.0    |
+| metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-8 | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v26.0.0    |
 | metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-7 | release-1.7  | release-1.7 | release-0.6    | v0.6.1         | latest      | v24.1.1    |
 | metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-6 | release-1.6  | release-1.6 | release-0.5    | v0.5.0         | latest      | v24.0.0    |
 | metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-5 | release-1.5  | release-1.5 | release-0.4    | v0.5.0         | latest      | v23.1.0    |
@@ -113,17 +114,17 @@ The table describes which branches/image-tags are tested in each periodic CI tes
 | FEATURE AND E2E TESTS                                            | CAPM3 branch | IPAM branch | BMO branch/tag | Keepalived tag | MariaDB tag | Ironic tag |
 | ---------------------------------------------------------------- | ------------ | ----------- | -------------- | -------------- | ----------- | ---------- |
 | metal3-periodic-centos-e2e-feature-test-main-pivoting            | main         | main        | main           | latest         | latest      | latest     |
-| metal3-periodic-centos-e2e-feature-test-release-1-8-pivoting     | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v25.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-8-pivoting     | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v26.0.0    |
 | metal3-periodic-centos-e2e-feature-test-release-1-7-pivoting     | release-1.7  | release-1.7 | release-0.6    | v0.6.1         | latest      | v24.1.1    |
 | metal3-periodic-centos-e2e-feature-test-release-1-6-pivoting     | release-1.6  | release-1.6 | release-0.5    | v0.5.0         | latest      | v24.0.0    |
 | metal3-periodic-centos-e2e-feature-test-release-1-5-pivoting     | release-1.5  | release-1.5 | release-0.4    | v0.4.0         | latest      | v23.1.0    |
 | metal3-periodic-centos-e2e-feature-test-main-remediation         | main         | main        | main           | latest         | latest      | latest     |
-| metal3-periodic-centos-e2e-feature-test-release-1-8-remediation  | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v25.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-8-remediation  | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v26.0.0    |
 | metal3-periodic-centos-e2e-feature-test-release-1-7-remediation  | release-1.7  | release-1.7 | release-0.6    | v0.6.1         | latest      | v24.1.1    |
 | metal3-periodic-centos-e2e-feature-test-release-1-6-remediation  | release-1.6  | release-1.6 | release-0.5    | v0.5.0         | latest      | v24.0.0    |
 | metal3-periodic-centos-e2e-feature-test-release-1-5-remediation  | release-1.5  | release-1.5 | release-0.4    | v0.4.0         | latest      | v23.1.0    |
 | metal3-periodic-centos-e2e-feature-test-main-features            | main         | main        | main           | latest         | latest      | latest     |
-| metal3-periodic-centos-e2e-feature-test-release-1-8-features     | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v25.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-8-features     | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v26.0.0    |
 | metal3-periodic-centos-e2e-feature-test-release-1-7-features     | release-1.7  | release-1.7 | release-0.6    | v0.6.1         | latest      | v24.1.1    |
 | metal3-periodic-centos-e2e-feature-test-release-1-6-features     | release-1.6  | release-1.6 | release-0.5    | v0.5.0         | latest      | v24.0.0    |
 | metal3-periodic-centos-e2e-feature-test-release-1-5-features     | release-1.5  | release-1.5 | release-0.4    | v0.4.0         | latest      | v23.1.0    |


### PR DESCRIPTION
This PR changes `release-1.8` branch tests to using ironic `release-26.0` branch and adds `release-26.0` branch to list of supported ironic branches.

Also marks v24.1 to `Tested` and v24.0 to `EOL`.