### PR TITLE
update version support tables for release-1.9

### DIFF
--- a/docs/user-guide/src/version_support.md
+++ b/docs/user-guide/src/version_support.md
@@ -17,9 +17,10 @@ Cluster API Provider Metal3
 
 | Minor release | API version | Status    |
 | ------------- | ----------- | --------- |
+| v1.9          | v1beta1     | Supported |
 | v1.8          | v1beta1     | Supported |
-| v1.7          | v1beta1     | Supported |
-| v1.6          | v1beta1     | Tested    |
+| v1.7          | v1beta1     | Tested    |
+| v1.6          | v1beta1     | EOL       |
 | v1.5          | v1beta1     | EOL       |
 | v1.4          | v1beta1     | EOL       |
 | v1.3          | v1beta1     | EOL       |
@@ -30,9 +31,10 @@ IP Address Manager
 
 | Minor release | API version | Status    |
 | ------------- | ----------- | --------- |
+| v1.9          | v1beta1     | Supported |
 | v1.8          | v1beta1     | Supported |
-| v1.7          | v1beta1     | Supported |
-| v1.6          | v1beta1     | Tested    |
+| v1.7          | v1beta1     | Tested    |
+| v1.6          | v1beta1     | EOL       |
 | v1.5          | v1beta1     | EOL       |
 | v1.4          | v1beta1     | EOL       |
 | v1.3          | v1beta1     | EOL       |
@@ -50,9 +52,10 @@ Following table summarizes BMO release/test process:
 
 | Minor release | Status    |
 | ------------- | --------- |
+| v0.9          | Supported |
 | v0.8          | Supported |
-| v0.6          | Supported |
-| v0.5          | Tested    |
+| v0.6          | Tested |
+| v0.5          | EOL    |
 | v0.4          | EOL       |
 | v0.3          | EOL       |
 | v0.2          | EOL       |
@@ -72,7 +75,7 @@ Following table summarizes Ironic-image release/test process:
 | v26.0         | Supported |
 | v25.0         | Supported |
 | v24.1         | Tested    |
-| v24.0         | Tested    |
+| v24.0         | EOL       |
 | v23.1         | EOL       |
 
 ## Image tags
@@ -104,24 +107,24 @@ The table describes which branches/image-tags are tested in each periodic CI tes
 | -------------------------------------------------------------- | ------------ | ----------- | -------------- | -------------- | ----------- | ---------- |
 | metal3-periodic-ubuntu/centos-e2e-integration-test-main        | main         | main        | main           | latest         | latest      | latest     |
 | metal3_periodic_main_integration_test_ubuntu/centos            | main         | main        | main           | latest         | latest      | latest     |
-| metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-8 | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v26.0.0    |
+| metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-9 | release-1.9  | release-1.9 | release-0.9    | v0.9.0         | latest      | v27.0.0    |
+| metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-8 | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v26.0.1    |
 | metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-7 | release-1.7  | release-1.7 | release-0.6    | v0.6.1         | latest      | v24.1.1    |
-| metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-6 | release-1.6  | release-1.6 | release-0.5    | v0.5.1         | latest      | v24.0.0    |
 
 | FEATURE AND E2E TESTS                                            | CAPM3 branch | IPAM branch | BMO branch/tag | Keepalived tag | MariaDB tag | Ironic tag |
 | ---------------------------------------------------------------- | ------------ | ----------- | -------------- | -------------- | ----------- | ---------- |
 | metal3-periodic-centos-e2e-feature-test-main-pivoting            | main         | main        | main           | latest         | latest      | latest     |
-| metal3-periodic-centos-e2e-feature-test-release-1-8-pivoting     | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v26.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-9-pivoting     | release-1.9  | release-1.9 | release-0.9    | v0.9.0         | latest      | v27.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-8-pivoting     | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v26.0.1    |
 | metal3-periodic-centos-e2e-feature-test-release-1-7-pivoting     | release-1.7  | release-1.7 | release-0.6    | v0.6.2         | latest      | v24.1.1    |
-| metal3-periodic-centos-e2e-feature-test-release-1-6-pivoting     | release-1.6  | release-1.6 | release-0.5    | v0.5.2         | latest      | v24.0.0    |
 | metal3-periodic-centos-e2e-feature-test-main-remediation         | main         | main        | main           | latest         | latest      | latest     |
-| metal3-periodic-centos-e2e-feature-test-release-1-8-remediation  | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v26.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-9-remediation  | release-1.9  | release-1.9 | release-0.9    | v0.9.0         | latest      | v27.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-8-remediation  | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v26.0.1    |
 | metal3-periodic-centos-e2e-feature-test-release-1-7-remediation  | release-1.7  | release-1.7 | release-0.6    | v0.6.2         | latest      | v24.1.1    |
-| metal3-periodic-centos-e2e-feature-test-release-1-6-remediation  | release-1.6  | release-1.6 | release-0.5    | v0.5.2         | latest      | v24.0.0    |
 | metal3-periodic-centos-e2e-feature-test-main-features            | main         | main        | main           | latest         | latest      | latest     |
-| metal3-periodic-centos-e2e-feature-test-release-1-8-features     | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v26.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-9-features     | release-1.9  | release-1.9 | release-0.9    | v0.9.0         | latest      | v27.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-8-features     | release-1.8  | release-1.8 | release-0.8    | v0.8.0         | latest      | v26.0.1    |
 | metal3-periodic-centos-e2e-feature-test-release-1-7-features     | release-1.7  | release-1.7 | release-0.6    | v0.6.2         | latest      | v24.1.1    |
-| metal3-periodic-centos-e2e-feature-test-release-1-6-features     | release-1.6  | release-1.6 | release-0.5    | v0.5.2         | latest      | v24.0.0    |
 
 | EPHEMERAL TESTS                                                | CAPM3 branch | IPAM branch | BMO branch/tag | Keepalived tag | MariaDB tag | Ironic tag |
 | -------------------------------------------------------------- | ------------ | ----------- | -------------- | -------------- | ----------- | ---------- |


### PR DESCRIPTION
Update version support tables for release-1.9.

Also update Ironic image 26.0.0 to 26.0.1 as it is really tested.