### PR TITLE
Mention redfish-virtual media in live-iso example

### DIFF
--- a/docs/user-guide/src/bmo/live-iso.md
+++ b/docs/user-guide/src/bmo/live-iso.md
@@ -24,6 +24,10 @@ kind: BareMetalHost
 metadata:
   name: live-iso-booted-node
 spec:
+  bootMACAddress: 80:c1:6e:7a:e8:10
+  bmc:
+    address: redfish-virtualmedia://192.168.111.1:8000/redfish/v1/Systems/1
+    credentialsName: live-iso-booted-node-secret
   image:
     url: http://1.2.3.4/image.iso
     format: live-iso


### PR DESCRIPTION
This commit aims to clarify that virtualmedia should be used when deploying with live-iso.