### PR TITLE
:seedling: Add broken link check action

### DIFF
--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -1,0 +1,12 @@
+name: PR Check Links
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  check-pr-links:
+    uses: metal3-io/project-infra/.github/workflows/pr-link-check.yml@main

--- a/.github/workflows/scheduled-link-check.yml
+++ b/.github/workflows/scheduled-link-check.yml
@@ -1,0 +1,17 @@
+name: Scheduled Link Check
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: "0 0 1 * *"
+  repository_dispatch:
+    # run manually
+    types: [check-links]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-links:
+    uses: metal3-io/project-infra/.github/workflows/scheduled-link-check.yml@main

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,5 @@
+# https://github.com/issues based urls give error 404 if user is not logged in.
+https://github.com/issues
+
+# Pages with rigorous bot detection
+https://www.dell.com/

--- a/docs/user-guide/src/capm3/features.md
+++ b/docs/user-guide/src/capm3/features.md
@@ -1,7 +1,7 @@
 # Cluster-api-provider-metal3 features
 
-- [Remediation](capm3/remediaton.md)
-- [Node Reuse](capm3/node_reuse.md)
-- [Pivoting](capm3/pivoting.md)
-- [Automated cleaning](capm3/automated_cleaning.md)
-- [Label synchronization](capm3/label_sync.md)
+- [Remediation](./remediaton.md)
+- [Node Reuse](./node_reuse.md)
+- [Pivoting](./pivoting.md)
+- [Automated cleaning](./automated_cleaning.md)
+- [Label synchronization](./label_sync.md)


### PR DESCRIPTION
Add lychee's broken link checker action. This checks all links except the ones specified in .lychee ignore. External links are checked as is. For internal .md links a corresponding file is looked for.  

I have tried this workflow in my own fork. You can check the result here: https://github.com/peppi-lotta/metal3-docs/actions/runs/13492952293

fixes: https://github.com/metal3-io/metal3-docs/issues/439