### PR TITLE
Remove mention of IronicDatabase from the IrSO docs

### DIFF
--- a/design/ironic-standalone-operator.md
+++ b/design/ironic-standalone-operator.md
@@ -243,6 +243,11 @@ The `IronicDatabase` object is very simple:
 - `image` - container image to use
 - `tlsRef` - a reference to a TLS secret to use for the service
 
+**NOTE:** after this design proposal was accepted, a decision [was
+made](https://github.com/metal3-io/ironic-standalone-operator/issues/142) to
+deprecate `IronicDatabase` in favour of 3rd party operators, such as [mariadb
+operator](https://github.com/mariadb-operator/mariadb-operator).
+
 The `Ironic` object is much more complex and should probably be split into more
 custom resources as we polish its internal architecture. Currently, it uses
 nested structures to logically group fields. Here are the most important fields

--- a/docs/user-guide/src/irso/introduction.md
+++ b/docs/user-guide/src/irso/introduction.md
@@ -35,9 +35,6 @@ IrSO uses two Custom Resources to manage an Ironic installation:
 [Ironic](https://github.com/metal3-io/ironic-standalone-operator/blob/main/config/crd/bases/ironic.metal3.io_ironics.yaml)
 manages Ironic itself and all of its auxiliary services.
 
-[IronicDatabase](https://github.com/metal3-io/ironic-standalone-operator/blob/main/config/crd/bases/ironic.metal3.io_ironicdatabases.yaml)
-manages a MariaDB instance for Ironic (if required).
-
 See [installing Ironic with IrSO](./install-basics.md) for information on how
 to use these resources.
 


### PR DESCRIPTION
We're going to deprecate it and mariadb-image in favour of 3rd party
operators, such as mariadb-operator. See the bug for more details:
https://github.com/metal3-io/ironic-standalone-operator/issues/142

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
