### PR TITLE
Set IRONIC_EXTERNAL_IP for virtualized environment

### DIFF
--- a/docs/user-guide/src/quick-start.md
+++ b/docs/user-guide/src/quick-start.md
@@ -370,6 +370,9 @@ HTTP_PORT=6180
 PROVISIONING_INTERFACE=eth0
 CACHEURL=http://192.168.222.1/images
 IRONIC_KERNEL_PARAMS=console=ttyS0
+# Docker does not allow cross-network access. If using kind to create the management
+# cluster, explicitly set the external ip and use port forwarding to access ironic services. 
+IRONIC_EXTERNAL_IP=192.168.222.1
 ```
 
 For more details on available variables, see the


### PR DESCRIPTION
If the management cluster is created using kind, the ironic inspector url will be https://172.18.0.2:5050. By default, docker does not allow direct cross-network, such as KVM VM (192.168.222.10X) -> Kind Container (172.18.0.2). This will make the KVM VM unable to contact inspector, making the baremetalhost stuck in inspecting state.

```shell
$ kubectl get bmh
NAME        STATE        CONSUMER   ONLINE   ERROR   AGE
bml-vm-01   inspecting              true             2m34s

$ virsh console bmh-vm-01
[  102.220928] ironic-python-agent[498]: 2025-06-03 01:15:51.135 498 INFO ironic_python_agent.inspector [-] Posting collected data to https://172.18.0.2:5050/v1/continue
[  137.264364] ironic-python-agent[498]: 2025-06-03 01:16:26.178 498 INFO ironic_python_agent.inspector [-] Posting collected data to https://172.18.0.2:5050/v1/continue
[  172.280336] ironic-python-agent[498]: 2025-06-03 01:17:01.194 498 INFO ironic_python_agent.inspector [-] Posting collected data to https://172.18.0.2:5050/v1/continue
[  208.311872] ironic-python-agent[498]: 2025-06-03 01:17:37.225 498 INFO ironic_python_agent.inspector [-] Posting collected data to https://172.18.0.2:5050/v1/continue
[  250.342934] ironic-python-agent[498]: 2025-06-03 01:18:19.257 498 INFO ironic_python_agent.inspector [-] Posting collected data to https://172.18.0.2:5050/v1/continue
[  280.378250] ironic-python-agent[498]: 2025-06-03 01:18:49.288 498 CRITICAL ironic-python-agent [-] Unhandled error: requests.exceptions.ConnectTimeout: HTTPSConnectionPool(host='172.18.0.2', port=5050): Max retries exceeded with url: /v1/continue (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x7f54547ddd00>, 'Connection to 172.18.0.2 timed out. (connect timeout=30)'))```

$ sudo iptables -t raw -nvL PREROUTING
Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination
 360K   30M DROP       all  --  !br-c22a230dcff6 *       0.0.0.0/0            172.18.0.2
    0     0 DROP       tcp  --  !lo    *       0.0.0.0/0            127.0.0.1            tcp dpt:43775
```

I've found two methods to fix this:

1. Remove the iptables rule manually, but the rule will come back after restarting docker and re-generating the iptables rules
2. Explicitly specify IRONIC_EXTERNAL_IP and use forward the traffic via the docker host

Not sure if there is a better way to let people know this in the doc since this is specific to the combination of docker+kind+virt