### PR TITLE
fix the broken link from CAPI

### DIFF
--- a/docs/user-guide/src/capm3/pivoting.md
+++ b/docs/user-guide/src/capm3/pivoting.md
@@ -68,7 +68,7 @@ bootstrap cluster.
 1. **Objects should have a proper owner reference chain.**
 
    `clusterctl move` moves all the objects to the target cluster following the
-   [owner reference chain](https://cluster-api.sigs.k8s.io/clusterctl/provider-contract.html#ownerreferences-chain).
+   [owner reference chain](https://cluster-api.sigs.k8s.io/developer/providers/contracts/clusterctl#ownerreferences-chain).
    So, it is necessary to verify that all the desired objects that needs to
    be moved to the target cluster have a proper owner reference chain.
 


### PR DESCRIPTION
This PR fixes broken link in the documentation by updating them to its new valid URLs in the Cluster API docs. This ensures all references work as expected and improves the reader experience.

Fixes: #536