### PR TITLE
Fix broken github links at annotation-for-power-cycling-and-deleting-failed-nodes.md

### DIFF
--- a/design/baremetal-operator/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/baremetal-operator/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -118,8 +118,8 @@ See [PoC code](https://github.com/kubevirt/machine-remediation/)
 ### Work Items
 
 - Make any requested modifications
-- Create a PR from [KubeVirt](github.com/kubevirt/machine-remediation)
-  into [CAPM3](github.com/metal3-io/cluster-api-provider-baremetal)
+- Create a PR from [KubeVirt](https://github.com/kubevirt/machine-remediation)
+  into [CAPM3](https://github.com/metal3-io/cluster-api-provider-baremetal)
 
 ### Dependencies
 


### PR DESCRIPTION
Fixed syntax of broken links in "annotation-for-power-cycling-and-deleting-failed-nodes.md" file

Broken link 1: (github.com/kubevirt/machine-remediation)
Broken link 2: (github.com/metal3-io/cluster-api-provider-baremetal)

Fixes #531 
