### PR TITLE
Fix broken link in troubleshooting.md

### DIFF
--- a/docs/user-guide/src/troubleshooting.md
+++ b/docs/user-guide/src/troubleshooting.md
@@ -54,7 +54,7 @@ Some things to look out for:
 
 First and foremost, avoid using forced deletion, otherwise you'll have [a
 conflict](#mac-address-conflict-on-registration). If you don't care about disks
-being [cleaned](automated_cleaning.md), you can edit the BareMetalHost resource
+being [cleaned](bmo/automated_cleaning.md), you can edit the BareMetalHost resource
 and disable cleaning:
 
 ```yaml


### PR DESCRIPTION
This PR fixes a broken link in the troubleshooting.md documentation referenced in the SUMMARY.md file. The issue was causing the build to fail due to an improperly formatted nested link in the summary file.

### Changes made:

- Corrected the link to troubleshooting.md in src/SUMMARY.md

- Updated src/troubleshooting.md for consistency.


Fixes: #535 


