### PR TITLE
Update multi-tenancy contract

### DIFF
--- a/design/cluster-api-provider-metal3/multi-tenancy_contract.md
+++ b/design/cluster-api-provider-metal3/multi-tenancy_contract.md
@@ -218,4 +218,4 @@ the Metal3Machines.
 ## References
 
 1. [CAPI multi-tenancy
-   contract](https://cluster-api.sigs.k8s.io/developer/architecture/controllers/multi-tenancy#contract)
+   contract](https://cluster-api.sigs.k8s.io/developer/providers/contracts/overview.html)


### PR DESCRIPTION
This PR fixes a broken link to the Cluster API (CAPI) multi-tenancy contract documentation in design/cluster-api-provider-metal3/multi-tenancy_contract.md.

Details

•  The original link (https://cluster-api.sigs.k8s.io/developer/architecture/controllers/multi-tenancy#contract) was returning a 404 error.
•  Updated the reference to the closest valid and relevant documentation:  
  https://cluster-api.sigs.k8s.io/developer/providers/contracts/overview.html

Motivation

Ensures that documentation references are accurate and helpful for users wanting further details about the CAPI provider contract and multi-tenancy support.