### PR TITLE
remove unused multilingual option from book.toml

### DIFF
--- a/docs/user-guide/book.toml
+++ b/docs/user-guide/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Metal³ community"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Metal³ user-guide"
 


### PR DESCRIPTION
Remove unused multilingual option as it has been removed from mdbook.

See https://github.com/szabgab/mdbooks.code-maven.com/issues/10

Supersedes stale #513.