### PR TITLE
Use netlify build container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
-MDBOOK_VERSION ?= 0.4.37
-MDBOOK_BIN_VERSION ?= v$(MDBOOK_VERSION)
+MDBOOK_BIN_VERSION ?= v0.4.37
 SOURCE_PATH := docs/user-guide
-CONTAINER_RUNTIME ?= sudo docker
+CONTAINER_RUNTIME ?= docker
 IMAGE_NAME := quay.io/metal3-io/mdbook
 IMAGE_TAG ?= latest
 HOST_PORT ?= 3000
@@ -43,13 +42,14 @@ netlify-build: $(RELEASETAGS) $(MDBOOK_BIN)
 
 .PHONY: build
 docker-build: # Build the mdbook container image
-	$(CONTAINER_RUNTIME) build --build-arg MDBOOK_VERSION=$(MDBOOK_VERSION) \
+	$(CONTAINER_RUNTIME) build --build-arg MDBOOK_RELEASE_URL=$(MDBOOK_RELEASE_URL) \
 	--tag $(IMAGE_NAME):$(IMAGE_TAG) -f docs/Dockerfile .
 
 .PHONY: build
 build:# Build the user guide
 	$(CONTAINER_RUNTIME) run \
 	--rm -it --name metal3 \
+	--user $$(id -u):$$(id -g) \
 	-v "$$(pwd):/workdir" \
 	$(IMAGE_NAME):$(IMAGE_TAG) \
 	mdbook build $(SOURCE_PATH)
@@ -58,6 +58,7 @@ build:# Build the user guide
 serve:# Serve the user-guide on localhost:3000 (by default)
 	$(CONTAINER_RUNTIME) run \
 	--rm -it --init --name metal3 \
+	--user $$(id -u):$$(id -g) \
 	-v "$$(pwd):/workdir" \
 	-p $(HOST_PORT):3000 \
 	$(IMAGE_NAME):$(IMAGE_TAG) \

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_IMAGE=docker.io/golang:1.21.9@sha256:7d0dcbe5807b1ad7272a598fbf9d7af15b5e2bed4fd6c4c2b5b3684df0b317dd
-FROM $BUILD_IMAGE as builder
+FROM $BUILD_IMAGE AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
@@ -22,10 +22,10 @@ ARG ARCH=amd64
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
   go build -tags=tools -a -ldflags '-extldflags "-static"' \
   -o mdbook-releasetags ./releasetags
+ARG MDBOOK_RELEASE_URL="https://github.com/rust-lang/mdBook/releases/download/v0.4.37/mdbook-v0.4.37-x86_64-unknown-linux-gnu.tar.gz"
+RUN curl -L "${MDBOOK_RELEASE_URL}" \
+  | tar xvz -C /workspace
 
-FROM rust:1.78.0-slim@sha256:517c6272b328bc51c87e099ef4adfbc7ab4558af2d757e8d423c7c3f1cbbf9d5
-ARG MDBOOK_VERSION="0.4.37"
-RUN cargo install mdbook --vers ${MDBOOK_VERSION}
-RUN cp /usr/local/cargo/bin/mdbook /usr/bin/mdbook
-COPY --from=builder /workspace/mdbook-releasetags /usr/bin/mdbook-releasetags
+FROM netlify/build:focal
 WORKDIR /workdir
+COPY --from=builder /workspace/mdbook-releasetags /workspace/mdbook /usr/bin/


### PR DESCRIPTION
This makes the build container much closer to the real netlify environment. We use their official build container and install mdbook the same way we do when publishing the site.

- Use official netlify build container
- Simplify variables (remove MDBOOK_VERSION)
- Download mdbook binary directly in container instead of building, same as netlify
- Set user/group ID for container mounts to avoid issues with file permissions