### PR TITLE
v1beta1: plan to remove BareMetalHost.Spec.Firmware

### DIFF
--- a/design/baremetal-operator/bmh-v1beta1.md
+++ b/design/baremetal-operator/bmh-v1beta1.md
@@ -117,6 +117,8 @@ The following cosmetic changes will be done to the new version:
   Note that using namespace other than the namespace of the BareMetalHost is
   already disallowed because of security concerns.
 
+- Remove the `Firmware` field since no maintained drivers support it any more.
+
 ### Implementation Details/Notes/Constraints
 
 Since the new API version will mostly involve removing or renaming fields,
@@ -203,6 +205,8 @@ On the path `v1alpha1` -> `v1beta1`:
 
   Rename the `DiskFormat` field in the structure definition to `Format` to be
   consistent with the field name in the API.
+
+- `Firmware` is removed without replacement.
 
 On the path `v1beta1` -> `v1alpha1`:
 


### PR DESCRIPTION
This field has only been supported by the iLO and iRMC drivers, and both
are now deprecated. Because of vast vendor differences, it's impractical
to implement the field for Redfish, so it will be removed in favour of
HostFirmwareSettings.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
