### PR TITLE
Fix link to CNCF services in design/community/foundation-proposal.md

### DIFF
--- a/design/community/foundation-proposal.md
+++ b/design/community/foundation-proposal.md
@@ -63,7 +63,7 @@ The [Goals](#goals) section discusses some of the immediate changes we should
 expect, but as the project continues to mature, many of the other services
 provided by the CNCF would be very beneficial to metal3-io.  The CNCF web site
 does a nice job discussing what services they offer projects on the
-[Services for CNCF Projects](https://www.cncf.io/services-for-projects/) page.
+[Services for CNCF Projects](https://contribute.cncf.io/resources/services/) page.
 
 ## Design Details
 


### PR DESCRIPTION
Fixes #602 
This PR updates the redirecting URL https://www.cncf.io/services-for-projects/ to its direct location https://contribute.cncf.io/resources/services/ as requested in the issue.