### PR TITLE
Update Slack community link in introduction.md

### DIFF
--- a/docs/user-guide/src/introduction.md
+++ b/docs/user-guide/src/introduction.md
@@ -49,7 +49,7 @@ clusters using Metal³...
 Metal³ is [open-source](https://github.com/metal3-io) and welcomes community
 contributions. The community meets at the following venues:
 
-* \#cluster-api-baremetal on [Kubernetes Slack](https://slack.k8s.io/)
+* \#cluster-api-baremetal on [Kubernetes Slack](https://communityinviter.com/apps/kubernetes/community)
 * Metal³ development [mailing list](https://groups.google.com/g/metal3-dev)
 * From the mailing list, you'll also be able to find the details of a weekly
   Zoom community call on Wednesdays at 14:00 GMT


### PR DESCRIPTION
Fixes #611.
This PR updates the redirecting URL https://slack.k8s.io/ to its direct location https://communityinviter.com/apps/kubernetes/community as requested in the issue.