### PR TITLE
Fix link to maintainers directory in documentation

### DIFF
--- a/processes/managing-reviewers.md
+++ b/processes/managing-reviewers.md
@@ -17,7 +17,7 @@ describes the process for adding reviewers to a metal3 project repo.
 
 ### Non-Goals
 
-1. Change the process for adding [maintainers](https://github.com/metal3-io/community/blob/main/maintainers/).
+1. Change the process for adding [maintainers](https://github.com/metal3-io/community/tree/main/maintainers).
 
 ## Proposal
 


### PR DESCRIPTION
Changed maintainers link to the correct link: https://github.com/metal3-io/community/tree/main/maintainers

Fixes: #614 

Signed-off-by: Kaif Ahmed Khan kaifkhan.rcs@gmail.com