### PR TITLE
docs: Fix link formatting in ironic-python-agent.md

### DIFF
--- a/docs/user-guide/src/ironic/ironic-python-agent.md
+++ b/docs/user-guide/src/ironic/ironic-python-agent.md
@@ -2,7 +2,7 @@
 
 [IPA](https://docs.openstack.org/ironic-python-agent/latest/) is a service written in python that runs within a ramdisk. It provides remote access for `Ironic` to perform various operations on the managed server. It also sends information about the server to `Ironic`.
 
-By default, we pull IPA images from [Ironic upstream](https://tarballs.opendev.org/openstack/ironic-python-agent/dib) archive where an image is built on every commit to the *master* git branch.
+By default, we pull IPA images from [Ironic upstream](https://tarballs.opendev.org/openstack/ironic-python-agent/dib/) archive where an image is built on every commit to the *master* git branch.
 
 However, another remote registry or a local IPA archive can be specified. [ipa-downloader](https://github.com/metal3-io/ironic-ipa-downloader) is responsible for downloading the IPA ramdisk image to a shared volume from where the nodes are able to retrieve it.
 


### PR DESCRIPTION
Fixes #613
This PR updates the redirecting URL https://tarballs.opendev.org/openstack/ironic-python-agent/dib to its direct location https://tarballs.opendev.org/openstack/ironic-python-agent/dib/ as requested in the issue.