### PR TITLE
docs: Update ipa_builder link to latest version

### DIFF
--- a/docs/user-guide/src/bmo/advanced_instance_customization.md
+++ b/docs/user-guide/src/bmo/advanced_instance_customization.md
@@ -56,5 +56,5 @@ spec:
 ```
 
 [network_data]: https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata
-[ipa_builder]: https://docs.openstack.org/ironic-python-agent-builder/
+[ipa_builder]: https://docs.openstack.org/ironic-python-agent-builder/latest/
 [simple_init]: https://docs.openstack.org/diskimage-builder/latest/elements/simple-init/README.html


### PR DESCRIPTION
Fixes #616.
This PR updates the redirecting URL https://docs.openstack.org/ironic-python-agent-builder/ to its direct location https://docs.openstack.org/ironic-python-agent-builder/latest/ as requested in the issue.