### PR TITLE
lint: allow long lines in tables and code fences, and fix everything

### DIFF
--- a/.cspell-config.json
+++ b/.cspell-config.json
@@ -236,6 +236,7 @@
     "UID",
     "unmanaged",
     "unmarshal",
+    "unsets",
     "Unported",
     "vars",
     "VBMC",

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -3,3 +3,4 @@ https://github.com/issues
 
 # Pages with rigorous bot detection
 https://www.dell.com/
+https://www.supermicro.com/

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,7 +4,9 @@ config:
   ul-indent:
     # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
     indent: 3
-  line-length: false
+  line-length:
+    tables: false
+    code_blocks: false
 
 # Don't autofix anything, we're linting here
 fix: false

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Kubernetes interfaces.
 
 ## Documentation
 
-Please see our [user-guide](https://book.metal3.io/) to familiarize yourself with Metal³ and its features. We are currently in the process of writing
+Please see our [user-guide](https://book.metal3.io/) to familiarize yourself
+with Metal³ and its features. We are currently in the process of writing
 the user-guide. As such, not all the topics might be covered yet.
 
 ## Community

--- a/design/baremetal-operator/annotation-for-power-cycling-and-deleting-failed-nodes.md
+++ b/design/baremetal-operator/annotation-for-power-cycling-and-deleting-failed-nodes.md
@@ -123,7 +123,7 @@ See [PoC code](https://github.com/kubevirt/machine-remediation/)
 
 ### Dependencies
 
-This design is intended to integrate with OpenShift’s [Machine HealthCheck
+This design is intended to integrate with OpenShift's [Machine HealthCheck
 implementation](https://github.com/openshift/machine-api-operator/blob/master/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go#L407)
 
 ### Test Plan

--- a/design/baremetal-operator/bmc-events.md
+++ b/design/baremetal-operator/bmc-events.md
@@ -70,7 +70,7 @@ metadata:
 spec:
    hostName: ostest-worker-1
    destination: https://events.apps.corp.example.com/webhook
-   context: “SomeUserContext”
+   context: "SomeUserContext"
    httpHeadersRef:
      name: some-secret-name
      namespace: some-namespace

--- a/design/baremetal-operator/bmh_non-bootable_iso.md
+++ b/design/baremetal-operator/bmh_non-bootable_iso.md
@@ -33,8 +33,9 @@ Expose the Ironic API to attach non-bootable iso images via Metal3.
 
 ### BMO Proposal
 
-Add a new Custom Resource(CR), `DataImage` (with same `name` and `namespace` as the BMH), which contains the spec containing details of the
-non-bootable iso image, example :
+Add a new Custom Resource(CR), `DataImage` (with same `name` and `namespace` as
+the BMH), which contains the spec containing details of the non-bootable iso
+image, example :
 
 #### Design spec
 
@@ -48,10 +49,11 @@ spec:
   url: http://1.2.3.4/image.iso
 ```
 
-We will use ownerReferences in the `DataImage` CR to link it to the corresponding `BareMetalHost` object.
+We will use ownerReferences in the `DataImage` CR to link it to the
+corresponding `BareMetalHost` object.
 
-Since we are using a CR, a user can create RBAC policies that doesn't allow unauthorized users
-to attach a non-bootable iso image to hosts.
+Since we are using a CR, a user can create RBAC policies that doesn't allow
+unauthorized users to attach a non-bootable iso image to hosts.
 
 We may consider adding support for HTTP credentials and TLS settings in the future
 but it's outside the scope of this proposal.
@@ -68,42 +70,49 @@ has been Provisioned or ExternallyProvisioned.
 
 ### Ironic Support
 
-The [proposal](https://bugs.launchpad.net/ironic/+bug/2033288) for exposing this functionality in Ironic has been
-accepted by the upstream Ironic community.
+The [proposal](https://bugs.launchpad.net/ironic/+bug/2033288) for exposing this
+functionality in Ironic has been accepted by the upstream Ironic community.
 
-The [Ironic implementation](https://review.opendev.org/c/openstack/ironic/+/894918) based on the above proposal has been completed.
+The [Ironic implementation](https://review.opendev.org/c/openstack/ironic/+/894918)
+based on the above proposal has been completed.
 
 Other than that, we just need the implementation for driver specific support,
 which in this proposal is Redfish.
 
 ## Design Details
 
-Create a new Custom Resource(CR), `DataImage`, with spec field `Url` and the same `Name`
-and `Namespace` as the `BareMetalHost` where we are attaching the image.
+Create a new Custom Resource(CR), `DataImage`, with spec field `Url` and the
+same `Name` and `Namespace` as the `BareMetalHost` where we are attaching the
+image.
 
-To attach an ISO, first the `DataImage` CR object is created and then it is attached to the
-BMH on its next reboot/power on.
+To attach an ISO, first the `DataImage` CR object is created and then it is
+attached to the BMH on its next reboot/power on.
 
 The `DataImage` `Status` will cache the image details including the attachment
 status, which will inform us if the attachment succeeded and can also be used
 for detachment - either when the attachment fails and we retry or when the user
-explicitly requests detachment by deleting the `DataImage` CRD that corresponds to a BMH.
+explicitly requests detachment by deleting the `DataImage` CRD that corresponds
+to a BMH.
 
-We will introduce a new flag, `NonBootableISOImage` (under `pkg/hardwareutils/bmc`), at the
-webhook level to validate if a given driver supports the non-bootable ISO feature.
+We will introduce a new flag, `NonBootableISOImage` (under
+`pkg/hardwareutils/bmc`), at the webhook level to validate if a given driver
+supports the non-bootable ISO feature.
 
 ### Implementation Details
 
-As part of the design we are assuming that to attach an image to a BMH object, the user
-will create the corresponding `DataImage` CR (with the same `Name` and `Namespace` as the
-`BareMetalHost` object). The BMH Controller will add the ownerReference for the corresponding BMH
-(example : [HostFirmwareSettings](https://github.com/metal3-io/baremetal-operator/blob/9ce684e6462a6ab55ff650cb6c11f9ba1ffb395d/docs/api.md?plain=1#L664)) and it will also add a finalizer to the `DataImage` after its attached.
-Then, on the next reboot/power-on of the BMH, the `DataImage` will be attached and the `DataImage`
-`Status` will be updated to reflect the status of the attachment, including which image was attached.
-In case of detachment of the ISO(`DataImage`), similar process will be followed where the actual
-detachment will happen on the next reboot/power-on and the `DataImage` Status will reflect the status
-of detachment, example : number of failures. The finalizer will also be removed once the
-detachment succeeds.
+As part of the design we are assuming that to attach an image to a BMH object,
+the user will create the corresponding `DataImage` CR (with the same `Name` and
+`Namespace` as the `BareMetalHost` object). The BMH Controller will add the
+ownerReference for the corresponding BMH (example:
+[HostFirmwareSettings](https://github.com/metal3-io/baremetal-operator/blob/9ce684e6462a6ab55ff650cb6c11f9ba1ffb395d/docs/api.md?plain=1#L664))
+and it will also add a finalizer to the `DataImage` after its attached. Then,
+on the next reboot/power-on of the BMH, the `DataImage` will be attached and
+the `DataImage` `Status` will be updated to reflect the status of the
+attachment, including which image was attached. In case of detachment of the
+ISO(`DataImage`), similar process will be followed where the actual detachment
+will happen on the next reboot/power-on and the `DataImage` Status will reflect
+the status of detachment, example : number of failures. The finalizer will also
+be removed once the detachment succeeds.
 Here is an example of what the `DataImage` `Status` might look like:
 
 ```yaml
@@ -116,24 +125,28 @@ status:
     url: "http://example.com/images/dataimage.iso"
 ```
 
-Since the attachment of the ISO happens when a BMH reconcile is triggered as a result of BMH
-reboot/power on, so handling the attachment/detachment of dataImage when the host reaches steady state (refer [`actionManageSteadyState` function](https://github.com/metal3-io/baremetal-operator/blob/9ce684e6462a6ab55ff650cb6c11f9ba1ffb395d/controllers/metal3.io/baremetalhost_controller.go#L1414) )
-makes sense since we only reach this state when a host has been either provisioned or externallyProvisioned, and
-any power state changes (including reboot via rebootAnnotation) are also handled after the host reaches this state
-( refer [`manageHostPower` function](https://github.com/metal3-io/baremetal-operator/blob/1bb45eef449c942711b1c0937ecff2b10a326eb3/controllers/metal3.io/baremetalhost_controller.go#L222) )
+Since the attachment of the ISO happens when a BMH reconcile is triggered as a
+result of BMH reboot/power on, so handling the attachment/detachment of
+dataImage when the host reaches steady state (refer
+[`actionManageSteadyState` function](https://github.com/metal3-io/baremetal-operator/blob/9ce684e6462a6ab55ff650cb6c11f9ba1ffb395d/controllers/metal3.io/baremetalhost_controller.go#L1414))
+makes sense since we only reach this state when a host has been either
+provisioned or externallyProvisioned, and any power state changes (including
+reboot via rebootAnnotation) are also handled after the host reaches this state
+(refer
+[`manageHostPower` function](https://github.com/metal3-io/baremetal-operator/blob/1bb45eef449c942711b1c0937ecff2b10a326eb3/controllers/metal3.io/baremetalhost_controller.go#L222)).
 
-We need to cache the attached image along with the attachment status in the `Status`
-of the `DataImage` to know if the image has been attached successfully. This
-will also help us determine if a different image was attached previously which
-needs to be detached first before attaching the new dataImage. Or, if the user
-deletes the dataImage CR and the `Status` contains a cached entry, which will
-again trigger detachment of that image.
+We need to cache the attached image along with the attachment status in the
+`Status` of the `DataImage` to know if the image has been attached
+successfully. This will also help us determine if a different image was
+attached previously which needs to be detached first before attaching the new
+dataImage. Or, if the user deletes the dataImage CR and the `Status` contains a
+cached entry, which will again trigger detachment of that image.
 
-In case the image fails to attach, we will retry until either the attachment succeeds
-or the user removes the dataImage CR. In case of failure in attachment, we will
-always do a detachment before the next retry, and record the reason for failure in the
-logs. In case of persistent failures, we will retry with increasing delays until the
-attachment/detachment succeeds.
+In case the image fails to attach, we will retry until either the attachment
+succeeds or the user removes the dataImage CR. In case of failure in
+attachment, we will always do a detachment before the next retry, and record
+the reason for failure in the logs. In case of persistent failures, we will
+retry with increasing delays until the attachment/detachment succeeds.
 
 ## Dependencies
 

--- a/design/baremetal-operator/bulk-set-bios-config.md
+++ b/design/baremetal-operator/bulk-set-bios-config.md
@@ -72,7 +72,7 @@ a more lightweight approach just for BIOS configuration.
 
 This proposal does not attempt to fulfill the following goals:
 
-- Allow the transfer of BIOS configuration between different vendor’s
+- Allow the transfer of BIOS configuration between different vendor's
   servers or different vendor models
 - Support bulk set of other configurations besides BIOS
 - Provide storage mechanism for BIOS settings
@@ -98,8 +98,8 @@ This ensures all the machines will have the identical settings, reducing issues
 caused by unexpected configuration differences.
 
 Since the name/value pair mapping is vendor specific and not intuitive, it
-doesn’t lend itself to creating the input by hand using existing vendor
-documentation, except for potentially a small subset of names. It’s desirable
+doesn't lend itself to creating the input by hand using existing vendor
+documentation, except for potentially a small subset of names. It's desirable
 to take an existing BIOS config set and modify the current settings to the
 desired settings. The BIOS Registry can be used as a source of documentation
 to modify the settings.

--- a/design/baremetal-operator/firmware-interface.md
+++ b/design/baremetal-operator/firmware-interface.md
@@ -84,7 +84,7 @@ After executing the cleaning, Ironic will re-read the information about the
 firmware components and cache them, the new information can be retrieved by
 the BMO and used to update `components`.
 
-If the update fails we won’t keep trying to reconcile, the BMO will put the
+If the update fails we won't keep trying to reconcile, the BMO will put the
 node in a `FirmwareUpdateError` state. We will allow deletion of the BMH when
 in this state. When in `FirmwareUpdateError` state the following actions can
 be executed:

--- a/design/baremetal-operator/hardwaredata_crd.md
+++ b/design/baremetal-operator/hardwaredata_crd.md
@@ -14,22 +14,27 @@ Introduce HardwareData Custom Resource (CR) to store host inspection data.
 
 Currently inspection data is written to baremetalhost status subresource. When
 pivoting to a target cluster, with *`clusterctl move`*, status subresource is
-not copied with the host, because from Cluster-API perspective, it's controllers'
-job to rebuild the status in the target cluster. Also, according to the [Kubernetes API convention](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status), status is expected to be reconstructed by controllers if
-it's lost for any reason. Baremetal Operator (BMO) is capable of reconstructing
-host status by re-inspecting the host, but it will force the already provisioned
-host to go through another round of provisioning, which eventually reboots the
-host after IPA steps are completed. To have the inspection data available in the
-target cluster and to avoid unnecessary provisioning after pivoting, we currently
-copy inspection data to baremetalhost.metal3.io/status annotation so that BMO in
-the target cluster can reconstruct the BareMetalHost from the annotation with the
-appropriate inspection data and as such the reconciliation of the BMH can continue
-from the same state as it was in the source cluster.
+not copied with the host, because from Cluster-API perspective, it's
+controllers' job to rebuild the status in the target cluster. Also, according
+to the
+[Kubernetes API convention](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status),
+status is expected to be reconstructed by controllers if it's lost for any
+reason. Baremetal Operator (BMO) is capable of reconstructing host status by
+re-inspecting the host, but it will force the already provisioned host to go
+through another round of provisioning, which eventually reboots the host after
+IPA steps are completed. To have the inspection data available in the target
+cluster and to avoid unnecessary provisioning after pivoting, we currently copy
+inspection data to baremetalhost.metal3.io/status annotation so that BMO in the
+target cluster can reconstruct the BareMetalHost from the annotation with the
+appropriate inspection data and as such the reconciliation of the BMH can
+continue from the same state as it was in the source cluster.
 
-However, there is a limitation with the current approach, because when inspection
-data is very large (e.g. when the host has 1000 multipath disks), it is easy to hit
-the global limit of `metadata.annotations` [262144](https://github.com/kubernetes/kubernetes/blob/master/test/integration/controlplane/synthetic_controlplane_test.go#L313) bytes and once the limit is hit
-the move process will fail to pivot BareMetalHosts successfully.
+However, there is a limitation with the current approach, because when
+inspection data is very large (e.g. when the host has 1000 multipath disks), it
+is easy to hit the global limit of `metadata.annotations`
+[262144](https://github.com/kubernetes/kubernetes/blob/master/test/integration/controlplane/synthetic_controlplane_test.go#L313)
+bytes and once the limit is hit the move process will fail to pivot
+BareMetalHosts successfully.
 
 ### Goals
 
@@ -47,84 +52,96 @@ the move process will fail to pivot BareMetalHosts successfully.
 
 ### User Stories
 
-As an operator, from an ephemeral cluster I would like to pivot/move all the Cluster
-API, CAPM3 and BMO objects to a target cluster successfully.
+As an operator, from an ephemeral cluster I would like to pivot/move all the
+Cluster API, CAPM3 and BMO objects to a target cluster successfully.
 
 ## Design Details
 
-Apart from writing hardware details into the status of BareMetalHost, write it to a
-HardwareData CR spec. BareMetalHost and HardwareData will be parent and child objects
-respectively, and this relationship is controlled via ownerReferences chain. As such,
-the same name and namespace will be used for HardwareData as its owning object BareMetalHost.
-The spec of HardwareData will contain the same fields & hardware information as currently
-under `status.hardware` of BareMetalHost.
+Apart from writing hardware details into the status of BareMetalHost, write it
+to a HardwareData CR spec. BareMetalHost and HardwareData will be parent and
+child objects respectively, and this relationship is controlled via
+ownerReferences chain. As such, the same name and namespace will be used for
+HardwareData as its owning object BareMetalHost. The spec of HardwareData will
+contain the same fields & hardware information as currently under
+`status.hardware` of BareMetalHost.
 
-OwnerReferences refers to the linked BareMetalHost and is added by the operator.
-To see all the available fields of ObjectReference type, check [core/v1](https://pkg.go.dev/k8s.io/api/core/v1#ObjectReference) package.
+OwnerReferences refers to the linked BareMetalHost and is added by the
+operator. To see all the available fields of ObjectReference type, check
+[core/v1](https://pkg.go.dev/k8s.io/api/core/v1#ObjectReference) package.
 
-There will be duplication of inspection data, i.e.,in the HardwareData spec and BareMetalHost
-status, for the purpose of avoiding breaking API changes. However, we plan to drop
+There will be duplication of inspection data, i.e.,in the HardwareData spec and
+BareMetalHost status, for the purpose of avoiding breaking API changes.
+However, we plan to drop
 [hardware](https://github.com/metal3-io/baremetal-operator/blob/05d12b6768a9989a9a4e61dad6cd1f9e84a6e078/apis/metal3.io/v1alpha1/baremetalhost_types.go#L721)
 field from the status of BareMetalHost in the first version bump of the API.
 
 ### Pivoting
 
-To pivot objects excluded from Cluster API chain to a target cluster, one can set
-`clusterctl.cluster.x-k8s.io=""` label on HardwareData and BareMetalHost CRDs.
-Current status annotation based pivoting workflow will stay as it is. However,
-CAPM3 machine controller will no longer copy `status.hardware` of BareMetalHost
-to the annotation. Because that part will be available in the form of HardwareData CR
-in the target cluster.
+To pivot objects excluded from Cluster API chain to a target cluster, one can
+set `clusterctl.cluster.x-k8s.io=""` label on HardwareData and BareMetalHost
+CRDs. Current status annotation based pivoting workflow will stay as it is.
+However, CAPM3 machine controller will no longer copy `status.hardware` of
+BareMetalHost to the annotation. Because that part will be available in the
+form of HardwareData CR in the target cluster.
 
 ### Implementation Details/Notes/Constraints
 
-The life of HardwareData is dependent on BareMetalHost. When BareMetalHost is entering
-inspection state, the HardwareData will be created. Failure in reaching inspection state
-or having `inspect.metal3.io: disabled` (without `inspect.metal3.io/hardwaredetails`
-annotation) annotation on BareMetalHost will force the operator to not create the
-HardwareData. Deleting a BareMetalHost will result in deletion of a HardwareData respectively.
+The life of HardwareData is dependent on BareMetalHost. When BareMetalHost is
+entering inspection state, the HardwareData will be created. Failure in
+reaching inspection state or having `inspect.metal3.io: disabled` (without
+`inspect.metal3.io/hardwaredetails` annotation) annotation on BareMetalHost
+will force the operator to not create the HardwareData. Deleting a
+BareMetalHost will result in deletion of a HardwareData respectively.
 
-HardwareData should be immutable and this will be controlled via [Validating Webhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook) and with RBAC permissions.
-In case, when [re-inspection](https://github.com/metal3-io/baremetal-operator/blob/master/docs/inspectAnnotation.md) of a `available` BareMetalHost is requested,
-new HardwareData will be re-created, because updating the old HardwareData will be
-blocked by the Validating Webhook.
+HardwareData should be immutable and this will be controlled via
+[Validating Webhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook)
+and with RBAC permissions. In case, when
+[re-inspection](https://github.com/metal3-io/baremetal-operator/blob/master/docs/inspectAnnotation.md)
+of a `available` BareMetalHost is requested, new HardwareData will be
+re-created, because updating the old HardwareData will be blocked by the
+Validating Webhook.
 
 Deprovisioning of the BareMetalHost must not delete the HardwareData. It can
 be deleted either when BareMetalHost is being deleted or when re-inspection
-is requested. To ensure HardwareData availability while BareMetalHost is provisioned,
-a finalizer should be set on the HardwareData.
+is requested. To ensure HardwareData availability while BareMetalHost is
+provisioned, a finalizer should be set on the HardwareData.
 
-Only operator will be granted with create permissions for HardwareData and everyone
-else will be given no write permissions. If the BareMetalHost was inspected but
-HardwareData is missing, operator acts differently depending on the current
-state of the BareMetalHost.
+Only operator will be granted with create permissions for HardwareData and
+everyone else will be given no write permissions. If the BareMetalHost was
+inspected but HardwareData is missing, operator acts differently depending on
+the current state of the BareMetalHost.
 
-- host is provisioned: we expect that HardwareData never existed. Even if it was existed
-    but user deleted it, then it is user's fault. Normally finalizer blocks HardwareData
-    deletion until BareMetalHost exists.
+- host is provisioned: we expect that HardwareData never existed. Even if it
+    was existed but user deleted it, then it is user's fault. Normally
+    finalizer blocks HardwareData deletion until BareMetalHost exists.
 - host is available:
     1. copy inspection data from the status of BareMetalHost if exists;
-    2. re-inspect the host if inspection data doesn't exist in the BareMetalHost status.
-        This will be the first and only option in the future when `status.hardware` is removed;
+    2. re-inspect the host if inspection data doesn't exist in the BareMetalHost
+        status. This will be the first and only option in the future when
+        `status.hardware` is removed;
 
-As mentioned above, we will have two copies of inspection data available for the
-time being. One in the Spec of HardwareData and the other in the Status of BareMetalHost.
-In the future, when new API version of BareMetalHost is introduced, `status.hardware`
-will be removed from BareMetalHost. As such, missing HardwareData for available BareMetalHost
-will result in another inspection before starting provisioning.
+As mentioned above, we will have two copies of inspection data available for
+the time being. One in the Spec of HardwareData and the other in the Status of
+BareMetalHost. In the future, when new API version of BareMetalHost is
+introduced, `status.hardware` will be removed from BareMetalHost. As such,
+missing HardwareData for available BareMetalHost will result in another
+inspection before starting provisioning.
 
-**Note:** [cross-namespace owner references are not allowed](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owner-references-in-object-specifications). Thus, HardwareData
-and BareMetalHost must be in the same namespace.
+**Note:**
+[cross-namespace owner references are not allowed](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owner-references-in-object-specifications).
+Thus, HardwareData and BareMetalHost must be in the same namespace.
 
 #### Example of HardwareData lifecycle
 
 - BareMetalHost is created
 - BareMetalHost is in inspecting state
-- Operator creates a HardwareData with the same name and namespace as BareMetalHost, fills out
-    the HardwareData with the host inspection data and sets ownerReferences
+- Operator creates a HardwareData with the same name and namespace as
+    BareMetalHost, fills out the HardwareData with the host inspection data and
+    sets ownerReferences
 - Provisioning is requested
-- Pivoted to a target cluster, operator restores host inspection data from HardwareData and
-    the rest from status annotation (e.g. `status.Provisioning`, `status.poweredOn` and etc)
+- Pivoted to a target cluster, operator restores host inspection data from
+    HardwareData and the rest from status annotation (e.g.
+    `status.Provisioning`, `status.poweredOn` and etc)
 - Deprovisioning is requested
 - BareMetalHost deletion requested, operator deletes the HardwareData and BareMetalHost
 
@@ -220,8 +237,8 @@ None
 
 - Use k8s built in objects like ConfigMap/Secret. From security point of view, although,
     it is possible to restrict permissions to edit ConfigMaps (only to those
-    storing inspection data) based on the name (i.e. `resourceNames`), but it will add
-    complexity to the operator.
+    storing inspection data) based on the name (i.e. `resourceNames`), but it
+    will add complexity to the operator.
 - Increase metadata global limit. However, this does not always work as it is hard
     to know the maximum length of inspection data.
 - Add filters to filter-out unn inspection data?

--- a/design/baremetal-operator/how-ironic-works.md
+++ b/design/baremetal-operator/how-ironic-works.md
@@ -229,7 +229,7 @@ ironic 12.0.0 is: idrac, ilo, ipmi, irmc, redfish, snmp, and xclarity.
 
 Usually more info are provided, at least a node name and parameters to
 initialize the drivers, such as username and password, if needed, passed
-through the “driver_info” option.
+through the "driver_info" option.
 
 An example of a typical node create request in JSON format:
 
@@ -246,7 +246,7 @@ An example of a typical node create request in JSON format:
 ```
 
 The response, if successful, contains a complete record of the node in JSON
-format with provided or default ({}, “null”, or “”) values.
+format with provided or default ({}, "null", or "") values.
 
 ## Updating information about a hardware node in ironic
 
@@ -303,11 +303,11 @@ Starting with the bare metal node in the "available" provision_state:
 
    ```json
        {
-       {“op”: “replace”, “path”: “/instance_info”, “value”: {
-           “image_source”: “http://url-to-image”,
-           “image_os_hash_algo”: “sha256”,
-           “image_os_hash_value”: “abcdefghi…”}},
-       {“op”: “replace”, “path”: “/instance_uuid”, “value”: “anyuuidvalue”}},
+       {"op": "replace", "path": "/instance_info", "value": {
+           "image_source": "http://url-to-image",
+           "image_os_hash_algo": "sha256",
+           "image_os_hash_value": "abcdefghi…"}},
+       {"op": "replace", "path": "/instance_uuid", "value": "anyuuidvalue"}},
        }
    ```
 
@@ -340,7 +340,7 @@ Starting with the bare metal node in the "available" provision_state:
    ```
 
    The particular interfaces that would be important to pay attention to are
-   ‘boot’, ‘deploy’, ‘power’, ‘management’.
+   'boot', 'deploy', 'power', 'management'.
 
    More information can be found in the [API documentation](https://developer.openstack.org/api-ref/baremetal/?expanded=validate-node-detail).
 
@@ -349,7 +349,7 @@ Starting with the bare metal node in the "available" provision_state:
    Configuration drives are files that contain a small ISO9660 filesystem
    which contains configuration metadata and user defined "user-data".
 
-   1) Create a folder called “TEMPDIR”
+   1) Create a folder called "TEMPDIR"
    2) In the case of ignition based configuration, that file would be
       renamed "user_data" and placed in `TEMPDIR/openstack/latest/`
       folder.
@@ -358,7 +358,7 @@ Starting with the bare metal node in the "available" provision_state:
       `TEMPDIR/openstack/latest` as well. This is out of scope, but is well
       documented in the OpenStack community.
    4) Create an iso9660 image containing the contents of TEMPDIR using
-      a label of “config-2”.
+      a label of "config-2".
    5) Compress the resulting ISO9660 image file using the gzip
       algorithm.
    6) Encode the resulting gzip compressed image file in base64 for
@@ -369,8 +369,8 @@ Starting with the bare metal node in the "available" provision_state:
    the deployment
 
    ```json
-       {“target”: “active”,
-        “configdrive”: “http://url-to-config-drive/node.iso.gz”}
+       {"target": "active",
+        "configdrive": "http://url-to-config-drive/node.iso.gz"}
    ```
 
    Once the request to make the node active has been received by ironic,

--- a/design/baremetal-operator/limit-hosts-provisioning.md
+++ b/design/baremetal-operator/limit-hosts-provisioning.md
@@ -77,9 +77,9 @@ if provisioning_slots < 0 then
 
 ### Risks and Mitigations
 
-- In a worst case scenario we could have a high number of “bad” hosts under
+- In a worst case scenario we could have a high number of "bad" hosts under
   provisioning but into an error state not recoverable. If such number is equal
-  to the configured threshold, then the “bad” hosts could prevent other hosts
+  to the configured threshold, then the "bad" hosts could prevent other hosts
   to be correctly provisioned. A fair scheduling approach will be required
   to ensure that the available provisioning slots will be distributed evenly
   (the recently added _BMH ErrorCount_ field could be used for that)

--- a/design/cluster-api-provider-metal3/allow_disabling_node_disk_cleaning.md
+++ b/design/cluster-api-provider-metal3/allow_disabling_node_disk_cleaning.md
@@ -24,7 +24,7 @@ Currently, when provisioning & de-provisioning Ironic nodes go
 through the [automated-cleaning](https://docs.openstack.org/ironic/latest/admin/cleaning.html#automated-cleaning)
 operation by default. This operation wipes out all the available
 disks on every node. While upgrade operations in Kubernetes,
-we want to ensure we don’t lose the data on the disks attached to
+we want to ensure we don't lose the data on the disks attached to
 the nodes. As such, we need a way to disable automated cleaning per
 node so that we can avoid disk cleaning while upgrading the cluster node(s).
 
@@ -32,12 +32,12 @@ node so that we can avoid disk cleaning while upgrading the cluster node(s).
 
 #### Story 1
 
-As a cluster admin, I would like my node’s disks data kept untouched
+As a cluster admin, I would like my node's disks data kept untouched
 while I'm upgrading my Kubernetes cluster node(s).
 
 #### Story 2
 
-As a cluster admin, I would like my node’s disks to be cleaned
+As a cluster admin, I would like my node's disks to be cleaned
 while provisioning/de-provisioning (i.e. not upgrade scenario)
 operations.
 
@@ -73,7 +73,7 @@ In the Metal³, we will need changes both in CAPM3 and BMO as follows
 
 We introduce a new field `automatedCleaningMode` in the spec of the
 Metal3MachineTemplate object. `automatedCleaningMode` store a enum type
-of value. Setting it to Disabled means don’t perform automated cleaning, while
+of value. Setting it to Disabled means don't perform automated cleaning, while
 Metadata value enables automated cleaning. By default, `automatedCleaningMode` will
 be set to Metadata (i.e. do perform automated cleaning as it is now).
 

--- a/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md
+++ b/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md
@@ -27,7 +27,8 @@ recovery of unhealthy nodes we need a programmatic way to put them back into a
 safe and healthy state.
 
 The Cluster API includes an optional
-[MachineHealthcheck](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking) (MHC)
+[MachineHealthcheck](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking)
+(MHC)
 component that implements automated health checking capability, and with
 the [External Remediation proposal](https://github.com/kubernetes-sigs/cluster-api/pull/3190)
 it will be possible to plug in Metal3 specific remediation strategies to
@@ -40,7 +41,7 @@ meet unhealthiness criteria set by Cluster API MHC.
 
 ### Goals
 
-* Enable automated remediation that doesn’t always reprovision the node.
+* Enable automated remediation that doesn't always reprovision the node.
 * Integrate with Cluster API MHC.
 * Support remediation based on power cycling the underlying hardware.
 * Support use of BMO reboot API and Cluster-API-Provider-Metal3 (CAPM3)

--- a/design/community/book-proposal.md
+++ b/design/community/book-proposal.md
@@ -22,7 +22,7 @@ the project to make the user getting-started experience easier.
 
 Currently all the documentation describing different parts
 of the Metal³ project is scattered across different repositories
-which doesn’t bring a good user experience from the documentation
+which doesn't bring a good user experience from the documentation
 perspective.
 
 ### Goals
@@ -82,7 +82,7 @@ There are two possible ways for that.
 
 **Where do we store mdbook auto-generated files like CSS/HTML ?**
 
-Since we are using Netlify, we don’t have to store those files within the Metal3-docs
+Since we are using Netlify, we don't have to store those files within the Metal3-docs
 Github repository. Because, Netlify will run the mdbook binary, which will be looking
 for the book structure file in `.toml` format. As such, the user-guide is generated
 on the fly, and the output (i.e. online user-guide) is stored and published via
@@ -100,7 +100,7 @@ and publish the final-user guide and a temporary URL.
 
 Netlify allows us to configure automatic-triggering N times per day. As such,
 we can decide how many times in a day we want to trigger it. And it actually
-depends on what’s the frequency of PRs in the Metal3-docs repository. But since
+depends on what's the frequency of PRs in the Metal3-docs repository. But since
 the frequency of the documentation is very low we can configure it to be once a
 day for now.
 

--- a/design/community/foundation-proposal.md
+++ b/design/community/foundation-proposal.md
@@ -32,7 +32,7 @@ more important.  If the project worked out and we started building a community,
 then we would revisit formalizing project governance for the future.
 
 After a year, we have produced useful code and a community involving multiple
-companies has formed to collaborate.  It’s a good time to consider what changes
+companies has formed to collaborate.  It's a good time to consider what changes
 might best support this community for the future.
 
 Some changes have already started happening, such as formalizing the process
@@ -94,7 +94,7 @@ the benefits of being more closely aligned with the CNCF ecosystem.
 
 The baremetal-operator makes use of Ironic, which came out of OpenStack.
 Ironic is hidden as an implementation detail, though.  In terms of where we
-expect the metal3 components to be used, it’s really more closely aligned with
+expect the metal3 components to be used, it's really more closely aligned with
 the Kubernetes ecosystem and the CNCF.
 
 ### Kubernetes Cluster Lifecycle SIG
@@ -105,7 +105,7 @@ provider itself could fall under this SIG, the scope of metal3-io is larger
 than supporting cluster-api.  metal3-io provides a Kubernetes API for generic
 bare metal host provisioning and cluster-api integration is just one use case.
 Since the scope of metal3-io is more broadly about bare metal host
-provisioning, we decided to organize it as an independent project.  It’s also
+provisioning, we decided to organize it as an independent project.  It's also
 convenient to keep the cluster-api provider along side the other related git
 repositories as part of metal3-io.  metal3-io community members do continue to
 collaborate with the cluster-api project.

--- a/design/fd-support-kcp.md
+++ b/design/fd-support-kcp.md
@@ -103,8 +103,8 @@ metadata:
 
 When CAPM3 reconciles the `Metal3Machine` object representing the control-plane
 Machine that KCP created, it will check if `Machine.Spec.FailureDomain` has a value,
-which in our example is fd-1. CAPM3 will pick a BMH that has the fd-1 label, such as
-the one we have defined above.
+which in our example is fd-1. CAPM3 will pick a BMH that has the fd-1 label,
+such as the one we have defined above.
 
 ## FD labels on the Node object
 

--- a/design/hostclaim-multitenancy.md
+++ b/design/hostclaim-multitenancy.md
@@ -283,10 +283,10 @@ cluster. However, the resources I intend to use (such as BareMetalHosts or
 KubeVirt virtual machines) will be defined in a separate cluster.
 
 The [multi-tenancy extension](./cluster-api-provider-metal3/multi-tenancy_contract.md)
-for BareMetalHost is extended to HostClaims. The Metal3Machine field ``identityRef`` points to a
-secret containing a kubeconfig object. This kubeconfig will be utilized instead
-of the HostClaim controller service account to create and manage HostClaim
-resources on the remote cluster.
+for BareMetalHost is extended to HostClaims. The Metal3Machine field
+`identityRef` points to a secret containing a kubeconfig object. This
+kubeconfig will be utilized instead of the HostClaim controller service account
+to create and manage HostClaim resources on the remote cluster.
 
 HostClaims do not have an identityRef field; they must be located on the same
 cluster as the BareMetalHost.
@@ -418,9 +418,9 @@ the associated BareMetalHost. It could be modified by a malicious tenant if the
 RBAC privileges are too lenient on the HostClaim namespace (right given to the
 user to modify not only the spec part but also the status part).
 
-But the BareMetalHost has also a consumer reference. The HostClaim status is only an
-indication of the binding. If the consumer reference and the HostClaim status
-differ, priority is given to the consumer reference on the BareMetalHost.
+But the BareMetalHost has also a consumer reference. The HostClaim status is
+only an indication of the binding. If the consumer reference and the HostClaim
+status differ, priority is given to the consumer reference on the BareMetalHost.
 
 #### Performance Impact
 
@@ -549,8 +549,8 @@ The disadvantages of the BareMetalPool approach are:
 
 The first proof of concept of HostClaims copied inspection data from the BareMetalHost
 to the HostClaim. There was no inventory of available hardware visible to the end-user.
-The code was also more complex especially because of metadata synchronization (details in
-the next section).
+The code was also more complex especially because of metadata synchronization
+(details in the next section).
 
 #### Alternative Handling of Metadata
 
@@ -558,21 +558,26 @@ Here are some alternative methods for handling metadata associated with BareMeta
 and used by the Metal3 provider (selection and construction of cloud-init/ignition
 data):
 
-* **Keep metadata in BareMetalHost. Copy to HostClaims** : the purpose of HostClaims is to hide
-  BareMetalHost from users. Selectors and important metadata values would be
-  hidden from their user. Even if infrastructure managers can convey information
-  through other means, this is awkward. The proof of concept had complex rules to maintain
-  HostClaim metadata synchronized with BareMetalHosts.
+* **Keep metadata in BareMetalHost. Copy to HostClaims** : the purpose of
+  HostClaims is to hide BareMetalHost from users. Selectors and important
+  metadata values would be hidden from their user. Even if infrastructure
+  managers can convey information through other means, this is awkward. The
+  proof of concept had complex rules to maintain HostClaim metadata synchronized
+  with BareMetalHosts.
 * **Metadata in HardwareData without synchronization** : infrastructure managers
-  must then create empty HardwareData to define the metadata visible to end users. This simplifies
-  HostDeployPolicy. The main drawback is that it is a non-compatible change with current deployments
-  of BareMetalHosts. Process annotating BareMetalHosts automatically would require modifications.
-* **Metadata in a new custom resource** : This custom resource would only exist for this purpose.
-  Having too many custom resources for a single concept is not a good idea.
-* **Keep some metadata on HardwareData not automatically synchronized with BareMetalHost metadata** :
-  metadata on HardwareData with keys that are not explicitly handled by the HostDeployPolicy would
-  be preserved. This is complex. The only purpose would be for automatic processes labeling HardwareData
-  based on their content, but they can always label BareMetalHost instead of HardwareData. The cost
-  of maintaining such partial synchronization is high.
+  must then create empty HardwareData to define the metadata visible to end
+  users. This simplifies HostDeployPolicy. The main drawback is that it is a
+  non-compatible change with current deployments of BareMetalHosts. Process
+  annotating BareMetalHosts automatically would require modifications.
+* **Metadata in a new custom resource** : This custom resource would only exist
+  for this purpose. Having too many custom resources for a single concept is not
+  a good idea.
+* **Keep some metadata on HardwareData not automatically synchronized with
+  BareMetalHost metadata** : metadata on HardwareData with keys that are not
+  explicitly handled by the HostDeployPolicy would be preserved. This is
+  complex. The only purpose would be for automatic processes labeling
+  HardwareData based on their content, but they can always label BareMetalHost
+  instead of HardwareData. The cost of maintaining such partial synchronization
+  is high.
 
 ## References

--- a/design/ip-address-manager/ip-address-management-for-networkdata.md
+++ b/design/ip-address-manager/ip-address-management-for-networkdata.md
@@ -394,11 +394,13 @@ The `fromPoolAnnotation` field can be used in:
 
 - Network configuration to specify which IPPool to use for IP address allocation
 - Gateway configuration to specify which IPPool to use for gateway IP resolution
-- Route gateway configuration to specify which IPPool to use for route gateway IP resolution
+- Route gateway configuration to specify which IPPool to use for route gateway
+  IP resolution
 
 The `fromPoolAnnotation` field contains:
 
-- **object**: The object type to read the annotation from (`baremetalhost`, `machine`, `metal3machine`)
+- **object**: The object type to read the annotation from (`baremetalhost`,
+  `machine`, `metal3machine`)
 - **annotation**: The annotation key containing the IPPool name
 
 If the annotation does not exist, the IPPool name is rendered as an empty string,

--- a/design/ironic_authentication.md
+++ b/design/ironic_authentication.md
@@ -255,7 +255,7 @@ Ironic supports basic authentication. Ironic can also run with an HTTPS
 endpoint. However, offloading the encryption to a reverse proxy could help with
 regards to performances and encryption support. The reverse proxy could also
 take care of the authentication temporarily, or pass the headers to Ironic and
-Inspector. If not using Ironic’s built-in basic authentication, the endpoints
+Inspector. If not using Ironic's built-in basic authentication, the endpoints
 used by IPA must remain free of authentication.
 
 The content of the `htpasswd` file would need to be based on a shared secret

--- a/docs/presentations/README.md
+++ b/docs/presentations/README.md
@@ -25,8 +25,10 @@ test-image1.png  test-image2-capi.png test-presentation.html
 To test your presentation with the revealjs framework, there are two simple
 options:
 
-1. Copy the `dist` and `plugin` directories from revealjs repository to the presentations directory.
-2. Copy all the presentation files under the revealjs repository and open the presentation `.html` file inside a browser.
+1. Copy the `dist` and `plugin` directories from revealjs repository to the
+   presentations directory.
+2. Copy all the presentation files under the revealjs repository and open the
+   presentation `.html` file inside a browser.
 
 Here is an example :
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -12,7 +12,9 @@ Each GitHub project has its own directory to keep related documents.For example:
 - `docs/user-guide/src/ironic` for Ironic related content
 - `docs/user-guide/src/ipam` for Ip-address-manager related content
 
-Similarly, we have the copy of the OWNERS file from each project, which gives reviewer and approver rights on the docs to the same maintainers of the project:
+Similarly, we have the copy of the OWNERS file from each project, which gives
+reviewer and approver rights on the docs to the same maintainers of the
+project:
 
 - `docs/user-guide/src/bmo/OWNERS`
 - `docs/user-guide/src/capm3/OWNERS`
@@ -21,9 +23,12 @@ Similarly, we have the copy of the OWNERS file from each project, which gives re
 
 ## Automatic build process
 
-Netlify is configured to build the user-guide periodically from the current state of the main branch. As such, when there is a documentation change merged, at the latest it will be visible in the official user-guide the next day.
+Netlify is configured to build the user-guide periodically from the current
+state of the main branch. As such, when there is a documentation change merged,
+at the latest it will be visible in the official user-guide the next day.
 
-Whenever build is triggered, Netlify will fetch the mdbook binary first and run `make build` to build the content.
+Whenever build is triggered, Netlify will fetch the mdbook binary first and run
+`make build` to build the content.
 This generates HTML content to be published under `docs/user-guide/book` directory.
 Last step, Netlify publishes the final content from `docs/user-guide/book`.
 The final content is built on the fly by Netlify as such, we don't store it on GitHub.
@@ -34,13 +39,17 @@ The final content is built on the fly by Netlify as such, we don't store it on G
 
 ## How to check book content when reviewing a GitHub patch
 
-Netlify is configured to build the book from a pull request branch and it will be reported on the PR as `netlify/metal3-user-guide/deploy-preview`.
-As such, it helps reviewers to review the patch not as the markdown only but also as the final user-guide.
+Netlify is configured to build the book from a pull request branch and it will
+be reported on the PR as `netlify/metal3-user-guide/deploy-preview`.
+As such, it helps reviewers to review the patch not as the markdown only but
+also as the final user-guide.
 Our Netlify configuration is in the [netlify.toml](https://github.com/metal3-io/metal3-docs/blob/main/netlify.toml).
 
 ## Mdbook maintenance
 
-All the configurations of the mdbook, such as content path, version, from where to get the binary while building the user-guide is defined in the [Makefile](https://github.com/metal3-io/metal3-docs/blob/main/Makefile).
+All the configurations of the mdbook, such as content path, version, from where
+to get the binary while building the user-guide is defined in the
+[Makefile](https://github.com/metal3-io/metal3-docs/blob/main/Makefile).
 
 ```sh
 MDBOOK_BIN_VERSION ?= v0.4.15
@@ -56,7 +65,8 @@ MDBOOK_BIN := $(BIN_DIR)/mdbook
 
 ## How to preview changes locally
 
-Before submitting document change, you can run the same mdbook binary to preview the book.
+Before submitting document change, you can run the same mdbook binary to preview
+the book.
 
 1. Install the mdbook by following official docs [here](https://rust-lang.github.io/mdBook/)
 
@@ -68,4 +78,5 @@ Before submitting document change, you can run the same mdbook binary to preview
     ```
 
 You should have the user-guide available now at `localhost:3000`.
-Also, the serve command watches the `src` directory for changes and rebuilds the user-guide for every change.
+Also, the serve command watches the `src` directory for changes and rebuilds
+the user-guide for every change.

--- a/docs/user-guide/src/SUMMARY.md
+++ b/docs/user-guide/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Metal3 Project
 
-[comment]: After adding the releasetag preprocessor the build fails with output "thread 'main' panicked at '', src/utils/fs.rs:45:10" if there are links with empty paths.
+<!-- After adding the releasetag preprocessor the build fails with -->
+<!-- "thread 'main' panicked" if there are links with empty paths. -->
 
 [Introduction](introduction.md)
 

--- a/docs/user-guide/src/baremetal/guide.md
+++ b/docs/user-guide/src/baremetal/guide.md
@@ -1,12 +1,15 @@
 # Baremetal provisioning
 
-This is a guide to provision baremetal servers using the Metal³ project. It is a generic guide with basic implementation, different hardware may require different configuration.
+This is a guide to provision baremetal servers using the Metal3 project. It is
+a generic guide with basic implementation, different hardware may require
+different configuration.
 
 In this guide we will use minikube as management cluster.
 
 All commands are executed on the host where minikube is set up.
 
-This is a separate machine, e.g. your laptop or one of the servers, that has access to the network where the servers are in order to provision them.
+This is a separate machine, e.g. your laptop or one of the servers, that has
+access to the network where the servers are in order to provision them.
 
 ## Install requirements on the host
 
@@ -63,13 +66,15 @@ See [Install Ironic](../ironic/ironic_installation.md) for other requirements.
 
 ## Prepare image cache
 
-- Start httpd container. This is used to host the the OS images that the BareMetalHosts will be provisioned with.
+- Start httpd container. This is used to host the the OS images that the
+  BareMetalHosts will be provisioned with.
 
   ```bash
   sudo docker run -d --net host --privileged --name httpd-infra -v /opt/metal3-dev-env/ironic:/shared --entrypoint /bin/runhttpd --env
   ```
 
-  Download the node image and put it in the folder where the httpd container can host it.
+  Download the node image and put it in the folder where the httpd container
+  can host it.
 
   ```bash
   wget -O /opt/metal3-dev-env/ironic/html/images https://artifactory.nordix.org/artifactory/metal3/images/k8s_v1.33.0
@@ -198,9 +203,11 @@ See [Install Ironic](../ironic/ironic_installation.md) for other requirements.
   kubectl apply -f ./bmh1.yaml -n metal3
   ```
 
-  At this point, the BareMetalHosts will go through `registering` and `inspection` phases before they become `available`.
+  At this point, the BareMetalHosts will go through `registering` and
+  `inspection` phases before they become `available`.
 
-  Wait for all of them to be available. You can check their status with `kubectl get bmh -n metal3`.
+  Wait for all of them to be available. You can check their status with
+  `kubectl get bmh -n metal3`.
 
   The next step is to create a workload cluster from these BareMetalHosts.
 

--- a/docs/user-guide/src/bmo/advanced_instance_customization.md
+++ b/docs/user-guide/src/bmo/advanced_instance_customization.md
@@ -8,29 +8,32 @@ For more general guidance around instance customization refer to the
 
 ## Pre-Provisioning NetworkData
 
-*Pre-provisioning network data* describes the desired networking configuration for the
-deploy ramdisk running `ironic-python-agent` (IPA).
+*Pre-provisioning network data* describes the desired networking configuration
+for the deploy ramdisk running `ironic-python-agent` (IPA).
 
-Usage of this API requires an IPA ramdisk image with a tool capable of interpreting and
-applying the data such as *cloud-init*, *Glean* or alternative. The default community
-supported ramdisk does not currently contain such a tool, but it is possible to build
-a custom image, for example using [ironic-python-agent-builder][ipa_builder] with the
-[simple-init][simple_init] element enabled.
+Usage of this API requires an IPA ramdisk image with a tool capable of
+interpreting and applying the data such as *cloud-init*, *Glean* or
+alternative. The default community supported ramdisk does not currently contain
+such a tool, but it is possible to build a custom image, for example using
+[ironic-python-agent-builder][ipa_builder] with the [simple-init][simple_init]
+element enabled.
 
-Specifying pre-provisioning network data is useful in DHCP-less scenarios, where we
-cannot rely on DHCP to provide network configuration for the IPA ramdisk during the
-inspection and provisioning phases. In this situation we can use redfish virtualmedia
-to boot the IPA ramdisk, and the generated virtualmedia ISO will also serve as a
-configuration drive to provide the network configuration.
+Specifying pre-provisioning network data is useful in DHCP-less scenarios,
+where we cannot rely on DHCP to provide network configuration for the IPA
+ramdisk during the inspection and provisioning phases. In this situation we can
+use redfish virtualmedia to boot the IPA ramdisk, and the generated virtualmedia
+ISO will also serve as a configuration drive to provide the network
+configuration.
 
 The data is specified in the [OpenStack network_data.json][network_data] format
-as described for *Network data* in the [instance customization](./instance_customization.md) section.
+as described for *Network data* in the
+[instance customization](./instance_customization.md) section.
 
-Usually, one pre-provisioning network data secret is created per host and should be
-linked to it like *Network data*. If you require the same configuration for
-pre-provisioning and the deployed OS, it is only necessary to specify pre-provisioning
-network data - the pre-provisioning secret is automatically applied to networkData if
-no alternative secret is specified.
+Usually, one pre-provisioning network data secret is created per host and
+should be linked to it like *Network data*. If you require the same
+configuration for pre-provisioning and the deployed OS, it is only necessary to
+specify pre-provisioning network data - the pre-provisioning secret is
+automatically applied to networkData if no alternative secret is specified.
 
 For example, given a local file `host-0-network.json`, you can create a secret:
 

--- a/docs/user-guide/src/bmo/automatic_secure_boot.md
+++ b/docs/user-guide/src/bmo/automatic_secure_boot.md
@@ -1,6 +1,10 @@
 # Automatic secure boot
 
-The automatic secure boot feature allows enabling and disabling UEFI (Unified Extensible Firmware Interface) secure boot when provisioning a host. This feature requires supported hardware and compatible OS image. The current hardwares that support enabling UEFI secure boot are `iLO`, `iRMC` and `Redfish` drivers.
+The automatic secure boot feature allows enabling and disabling UEFI (Unified
+Extensible Firmware Interface) secure boot when provisioning a host. This
+feature requires supported hardware and compatible OS image. The current
+hardwares that support enabling UEFI secure boot are `iLO`, `iRMC` and
+`Redfish` drivers.
 
 Check also:
 
@@ -9,11 +13,18 @@ Check also:
 
 ## Why do we need it
 
-We need the Automatic secure boot when provisioning a host with high security requirements. Based on checksum and signature, the secure boot protects the host from loading malicious code in the boot process before loading the provisioned operating system.
+We need the Automatic secure boot when provisioning a host with high security
+requirements. Based on checksum and signature, the secure boot protects the
+host from loading malicious code in the boot process before loading the
+provisioned operating system.
 
 ## How to use it
 
-To enable Automatic secure boot, first check if hardware is supported and then specify the value `UEFISecureBoot` for `bootMode` in the BareMetalHost custom resource. Please note, it is enabled before booting into the deployed instance and disabled when the ramdisk is running and on tear down. Below you can check the example:
+To enable Automatic secure boot, first check if hardware is supported and then
+specify the value `UEFISecureBoot` for `bootMode` in the BareMetalHost custom
+resource. Please note, it is enabled before booting into the deployed instance
+and disabled when the ramdisk is running and on tear down. Below you can check
+the example:
 
 ```YAML
 apiVersion: metal3.io/v1alpha1
@@ -27,4 +38,5 @@ spec:
   ...
 ```
 
-This will enable UEFI before booting the instance and disable it when deprovisioned. Note that the default value for `bootMode` is `UEFI`.
+This will enable UEFI before booting the instance and disable it when
+deprovisioned. Note that the default value for `bootMode` is `UEFI`.

--- a/docs/user-guide/src/bmo/detached_annotation.md
+++ b/docs/user-guide/src/bmo/detached_annotation.md
@@ -1,14 +1,17 @@
 # Detaching Hosts from Provisioner
 
-The detached annotation provides a way to prevent management of a BareMetalHost.
-It works by deleting the host information from Ironic without triggering deprovisioning.
-The BareMetal Operator will recreate the host in Ironic again once the annotation is removed.
-This annotation can be used with BareMetalHosts in `Provisioned`, `ExternallyProvisioned` or `Available` states.
+The detached annotation provides a way to prevent management of a
+BareMetalHost. It works by deleting the host information from Ironic without
+triggering deprovisioning. The BareMetal Operator will recreate the host in
+Ironic again once the annotation is removed. This annotation can be used with
+BareMetalHosts in `Provisioned`, `ExternallyProvisioned` or `Available` states.
 
-Normally, deleting a BareMetalHost will always trigger deprovisioning.
-This can be problematic and unnecessary if we just want to, for example, move the BareMetalHost from one cluster to another.
-By applying the annotation before removing the BareMetalHost from the old cluster, we can ensure that the host is not disrupted by this (normally it would be deprovisioned).
-The next step is then to recreate it in the new cluster without triggering a new inspection.
+Normally, deleting a BareMetalHost will always trigger deprovisioning. This can
+be problematic and unnecessary if we just want to, for example, move the
+BareMetalHost from one cluster to another. By applying the annotation before
+removing the BareMetalHost from the old cluster, we can ensure that the host is
+not disrupted by this (normally it would be deprovisioned). The next step is
+then to recreate it in the new cluster without triggering a new inspection.
 See the [status annotation page](./status_annotation.md) for how to do this.
 
 The detached annotation is also useful if you want to move the host under
@@ -20,8 +23,8 @@ For more details, please see the [design proposal](https://github.com/metal3-io/
 
 ## How to detach
 
-The annotation key is `baremetalhost.metal3.io/detached` and the value can be anything (it is ignored).
-Here is an example:
+The annotation key is `baremetalhost.metal3.io/detached` and the value can be
+anything (it is ignored). Here is an example:
 
 ```yaml
 apiVersion: metal3.io/v1alpha1

--- a/docs/user-guide/src/bmo/external_inspection.md
+++ b/docs/user-guide/src/bmo/external_inspection.md
@@ -1,13 +1,19 @@
 # External inspection
 
-Similar to the [status annotation](status_annotation.md), external inspection makes it possible to skip the inspection step.
-The difference is that the status annotation can only be used on the very first reconcile and allows setting all the fields under `status`.
-In contrast, external inspection limits the changes so that only HardwareDetails can be modified, and it can be used at any time when inspection is disabled (with the `inspect.metal3.io: disabled` annotation) or when there is no existing HardwareDetails data.
+Similar to the [status annotation](status_annotation.md), external inspection
+makes it possible to skip the inspection step. The difference is that the
+status annotation can only be used on the very first reconcile and allows
+setting all the fields under `status`. In contrast, external inspection limits
+the changes so that only HardwareDetails can be modified, and it can be used at
+any time when inspection is disabled (with the `inspect.metal3.io: disabled`
+annotation) or when there is no existing HardwareDetails data.
 
 External inspection is controlled through an annotation on the BareMetalHost.
-The annotation key is `inspect.metal3.io/hardwaredetails` and the value is a JSON representation of the BareMetalHosts `status.hardware` field.
+The annotation key is `inspect.metal3.io/hardwaredetails` and the value is a
+JSON representation of the BareMetalHosts `status.hardware` field.
 
-Here is an example with a BMH that has inspection disabled and is using the external inspection feature to add the HardwareDetails.
+Here is an example with a BMH that has inspection disabled and is using the
+external inspection feature to add the HardwareDetails.
 
 ```yaml
 apiVersion: metal3.io/v1alpha1
@@ -25,10 +31,15 @@ spec:
 
 Why is this needed?
 
-- It allows avoiding an extra reboot for live-images that include their own inspection tooling.
+- It allows avoiding an extra reboot for live-images that include their own
+  inspection tooling.
 - It provides an arguably safer alternative to the status annotation in some cases.
 
 Caveats:
 
-- If both `baremetalhost.metal3.io/status` and `inspect.metal3.io/hardwaredetails` are specified on BareMetalHost creation, `inspect.metal3.io/hardwaredetails` will take precedence and overwrite any hardware data specified via `baremetalhost.metal3.io/status`.
-- If the BareMetalHost is in the `Available` state the controller will not attempt to match profiles based on the annotation.
+- If both `baremetalhost.metal3.io/status` and
+  `inspect.metal3.io/hardwaredetails` are specified on BareMetalHost creation,
+  `inspect.metal3.io/hardwaredetails` will take precedence and overwrite any
+  hardware data specified via `baremetalhost.metal3.io/status`.
+- If the BareMetalHost is in the `Available` state the controller will not
+  attempt to match profiles based on the annotation.

--- a/docs/user-guide/src/bmo/install_baremetal_operator.md
+++ b/docs/user-guide/src/bmo/install_baremetal_operator.md
@@ -54,9 +54,9 @@ but overflows could happen in case of slow provisioners and / or higher number o
 concurrent reconciles. For such reasons, it is highly recommended to keep
 BMO_CONCURRENCY value lower than the requested PROVISIONING_LIMIT. Default is 20.
 
-`IRONIC_EXTERNAL_URL_V6` -- This is the URL where Ironic will find the image for
-nodes that use IPv6. In dual stack environments, this can be used to tell Ironic which IP
-version it should set on the BMC.
+`IRONIC_EXTERNAL_URL_V6` -- This is the URL where Ironic will find the image
+for nodes that use IPv6. In dual stack environments, this can be used to tell
+Ironic which IP version it should set on the BMC.
 
 ### Deprecated options
 
@@ -258,8 +258,9 @@ ironic-deployment/
 The `ironic-deployment` folder contains kustomizations for deploying Ironic.
 It makes use of kustomize components for basic auth, TLS and keepalived configurations.
 This makes it easy to combine the configurations, for example basic auth + TLS.
-There are some ready made overlays in the `overlays` folder that shows how this can be done.
-For more information, check the readme in the `ironic-deployment` folder.
+There are some ready made overlays in the `overlays` folder that shows how this
+can be done. For more information, check the readme in the `ironic-deployment`
+folder.
 
 ### Deployment commands
 

--- a/docs/user-guide/src/bmo/introduction.md
+++ b/docs/user-guide/src/bmo/introduction.md
@@ -6,13 +6,13 @@ resources*.
 
 BMO is responsible for the following operations:
 
-- Inspecting the host’s hardware and reporting the details on the corresponding
+- Inspecting the host's hardware and reporting the details on the corresponding
   BareMetalHost. This includes information about CPUs, RAM, disks, NICs, and
   more.
 - Optionally preparing the host by configuring RAID, changing firmware settings
   or updating the system and/or BMC firmware.
 - Provisioning the host with a desired image.
-- Cleaning the host’s disk contents before and after provisioning.
+- Cleaning the host's disk contents before and after provisioning.
 
 Under the hood, BMO uses [Ironic](../ironic/introduction) to conduct these
 actions.

--- a/docs/user-guide/src/bmo/live_updates_servicing.md
+++ b/docs/user-guide/src/bmo/live_updates_servicing.md
@@ -47,7 +47,8 @@ spec:
 updated
 - use the format above, ensure `firmwareSettings` and/or `firmwareUpdates` is
 set to `onReboot`
-- make changes to [HostFirmwareSettings](./firmware_settings.md) and/or [HostFirmwareComponents](./firmware_updates.md) as required
+- make changes to [HostFirmwareSettings](./firmware_settings.md) and/or
+  [HostFirmwareComponents](./firmware_updates.md) as required
 - make sure the modified resources are considered valid (see `Conditions`)
 - if you're updating a Kubernetes node, make sure to drain it and mark as
 not schedulable
@@ -98,8 +99,9 @@ kubectl uncordon worker-0
 Once changes similar to the above are made to the relevant CRDs, the following
 will occur:
 
-- BMO will generate [servicing steps](https://docs.openstack.org/ironic/latest/admin/servicing.html) (similar to manual cleaning steps)
-required to perform the requested changes
+- BMO will generate
+  [servicing steps](https://docs.openstack.org/ironic/latest/admin/servicing.html)
+  (similar to manual cleaning steps) required to perform the requested changes
 - BMH will transition to `servicing` operationalStatus
 - BMO will make calls to Ironic which will perform the servicing operation
 - Ironic will reboot the BMH into the IPA image and perform requested changes

--- a/docs/user-guide/src/bmo/status_annotation.md
+++ b/docs/user-guide/src/bmo/status_annotation.md
@@ -1,11 +1,15 @@
 # Reconstructing Host Status
 
-The status annotation is useful when you need to avoid inspection of a BareMetalHost.
-This can happen if the status is already known, for example, when moving the BareMetalHost from one cluster to another.
-By setting this annotation, the BareMetal Operator will take the status of the BareMetalHost directly from the annotation.
+The status annotation is useful when you need to avoid inspection of a
+BareMetalHost. This can happen if the status is already known, for example,
+when moving the BareMetalHost from one cluster to another. By setting this
+annotation, the BareMetal Operator will take the status of the BareMetalHost
+directly from the annotation.
 
-The annotation key is `baremetalhost.metal3.io/status` and the value is a JSON representation of the BareMetalHosts `status` field.
-One simple way of extracting the status and turning it into an annotation is using kubectl like this:
+The annotation key is `baremetalhost.metal3.io/status` and the value is a JSON
+representation of the BareMetalHosts `status` field. One simple way of
+extracting the status and turning it into an annotation is using kubectl like
+this:
 
 ```bash
 # Save the status in json format to a file
@@ -16,15 +20,20 @@ kubectl -n metal3 annotate bmh <name-of-bmh> \
   --dry-run=client -o yaml > bmh.yaml
 ```
 
-Note that the above example does not apply the annotation to the BareMetalHost directly since this is most likely not useful to apply it on one that already has a status.
-Instead it saves the BareMetalHost *with the annotation applied* to a file `bmh.yaml`.
-This file can then be applied in another cluster.
-The status would be discarded at this point since the user is usually not allowed to set it, but the annotation is still there and would be used by the BareMetal Operator to set status again.
-Once this is done, the operator will remove the status annotation.
-In this situation you may also want to check the [detached annotation](./detached_annotation.md) for how to remove the BareMetalHost from the old cluster without going through deprovisioning.
+Note that the above example does not apply the annotation to the BareMetalHost
+directly since this is most likely not useful to apply it on one that already
+has a status. Instead it saves the BareMetalHost *with the annotation applied*
+to a file `bmh.yaml`. This file can then be applied in another cluster. The
+status would be discarded at this point since the user is usually not allowed
+to set it, but the annotation is still there and would be used by the BareMetal
+Operator to set status again. Once this is done, the operator will remove the
+status annotation. In this situation you may also want to check the
+[detached annotation](./detached_annotation.md) for how to remove the
+BareMetalHost from the old cluster without going through deprovisioning.
 
-Here is an example of a BareMetalHost, first without the annotation, but with status and spec, and then the other way around.
-This shows how the status field is turned into the annotation value.
+Here is an example of a BareMetalHost, first without the annotation, but with
+status and spec, and then the other way around. This shows how the status field
+is turned into the annotation value.
 
 ```yaml
 apiVersion: metal3.io/v1alpha1

--- a/docs/user-guide/src/capm3/automated_cleaning.md
+++ b/docs/user-guide/src/capm3/automated_cleaning.md
@@ -2,39 +2,75 @@
 
 <!-- cSpell:ignore unsetting -->
 
-Before reading this page, please see [Baremetal Operator Automated Cleaning](../bmo/automated_cleaning.md) page.
+Before reading this page, please see
+[Baremetal Operator Automated Cleaning](../bmo/automated_cleaning.md) page.
 
-If you are using only Metal3 Baremetal Operator, you can skip this page and refer to Baremetal
-Operator automated cleaning [page](../bmo/automated_cleaning.md) instead.
+If you are using only Metal3 Baremetal Operator, you can skip this page and
+refer to Baremetal Operator automated cleaning
+[page](../bmo/automated_cleaning.md) instead.
 
-For deployments following Cluster-api-provider-metal3 (CAPM3) workflow, automated cleaning can
-be (recommended) configured via CAPM3 custom resources (CR).
+For deployments following Cluster-api-provider-metal3 (CAPM3) workflow,
+automated cleaning can be (recommended) configured via CAPM3 custom resources
+(CR).
 
-There are two automated cleaning modes available  which can be set via `automatedCleaningMode` field of a
-Metal3MachineTemplate `spec` or Metal3Machine `spec`.
+There are two automated cleaning modes available which can be set via
+`automatedCleaningMode` field of a Metal3MachineTemplate `spec` or
+Metal3Machine `spec`.
 
 - `metadata` to enable the cleaning
 - `disabled` to disable the cleaning
 
-When enabled (`metadata`), automated cleaning kicks off when a node is in the first provisioning and on every deprovisioning.
-There is no default value for `automatedCleaningMode` in Metal3MachineTemplate and Metal3Machine. If user doesn't set any mode,
-the field in the `spec` will be omitted. Unsetting `automatedCleaningMode` in the Metal3MachineTemplate will block the synchronization
-of the cleaning mode between the Metal3MachineTemplate and Metal3Machines. This enables the selective operations described below.
+When enabled (`metadata`), automated cleaning kicks off when a node is in the
+first provisioning and on every deprovisioning. There is no default value for
+`automatedCleaningMode` in Metal3MachineTemplate and Metal3Machine. If user
+doesn't set any mode, the field in the `spec` will be omitted. Unsetting
+`automatedCleaningMode` in the Metal3MachineTemplate will block the
+synchronization of the cleaning mode between the Metal3MachineTemplate and
+Metal3Machines. This enables the selective operations described below.
 
 ## Bulk operations
 
-CAPM3 controller ensures to replicate automated cleaning mode to all Metal3Machines from their referenced Metal3MachineTemplate.
-For example, one controlplane and one worker Metal3Machines have `automatedCleaningMode` set to `disabled`, because it is set to `disabled` in the template that they both are referencing.
+CAPM3 controller ensures to replicate automated cleaning mode to all
+Metal3Machines from their referenced Metal3MachineTemplate. For example, one
+controlplane and one worker Metal3Machines have `automatedCleaningMode` set to
+`disabled`, because it is set to `disabled` in the template that they both are
+referencing.
 
-**Note**: CAPM3 controller replicates the cleaning mode from Metal3MachineTemplate to Metal3Machine only if `automatedCleaningMode` is set (not empty) on the Metal3MachineTemplate resource. In other words, it synchronizes either `disabled` or `metadata` modes between Metal3MachineTemplate and Metal3Machines.
+**Note**: CAPM3 controller replicates the cleaning mode from
+Metal3MachineTemplate to Metal3Machine only if `automatedCleaningMode` is set
+(not empty) on the Metal3MachineTemplate resource. In other words, it
+synchronizes either `disabled` or `metadata` modes between Metal3MachineTemplate
+and Metal3Machines.
 
 ## Selective operations
 
-Normally automated cleaning mode is replicated from Metal3MachineTemplate `spec` to its referenced Metal3Machines' `spec` and from Metal3Machines `spec` to BareMetalHost `spec` (if CAPM3 is used). However, sometimes you might want to have a different automated cleaning mode for one or more Metal3Machines than the others even though they are referencing the same Metal3MachineTemplate. For example, there is one worker and one controlplane Metal3Machine created from the same Metal3MachineTemplate, and we would like the automated cleaning to be enabled (`metadata`) for the worker while disabled (`disabled`) for the controlplane.
+Normally automated cleaning mode is replicated from Metal3MachineTemplate `spec`
+to its referenced Metal3Machines' `spec` and from Metal3Machines `spec` to
+BareMetalHost `spec` (if CAPM3 is used). However, sometimes you might want to
+have a different automated cleaning mode for one or more Metal3Machines than
+the others even though they are referencing the same Metal3MachineTemplate. For
+example, there is one worker and one controlplane Metal3Machine created from
+the same Metal3MachineTemplate, and we would like the automated cleaning to be
+enabled (`metadata`) for the worker while disabled (`disabled`) for the
+controlplane.
 
 Here are the steps to achieve that:
 
-1. Unset `automatedCleaningMode` in the Metal3MachineTemplate. Then CAPM3 controller unsets it for referenced Metal3Machines. Although it is unset in the Metal3Machine, BareMetalHosts will get their default automated cleaning mode `metadata`. As we mentioned earlier, CAPM3 controller replicates cleaning mode from Metal3MachineTemplate to Metal3Machine ONLY when it is either `metadata` or `disabled`. As such, to block synchronization between Metal3MachineTemplate and Metal3Machine, unsetting the cleaning mode in the Metal3MachineTemplate is enough.
-1. Set `automatedCleaningMode` to `disabled` on the worker Metal3Machine `spec` and to `metadata` on the controlplane Metal3Machine `spec`. Since we don't have any mode set on the Metal3MachineTemplate, Metal3Machines can have different automated cleaning modes set even if they reference the same Metal3MachineTemplate. CAPM3 controller copies cleaning modes from Metal3Machines to their corresponding BareMetalHosts. As such, we end up with two nodes having different cleaning modes regardless of the fact that they reference the same Metal3MachineTemplate.
+1. Unset `automatedCleaningMode` in the Metal3MachineTemplate. Then CAPM3
+   controller unsets it for referenced Metal3Machines. Although it is unset in
+   the Metal3Machine, BareMetalHosts will get their default automated cleaning
+   mode `metadata`. As we mentioned earlier, CAPM3 controller replicates
+   cleaning mode from Metal3MachineTemplate to Metal3Machine ONLY when it is
+   either `metadata` or `disabled`. As such, to block synchronization between
+   Metal3MachineTemplate and Metal3Machine, unsetting the cleaning mode in the
+   Metal3MachineTemplate is enough.
+1. Set `automatedCleaningMode` to `disabled` on the worker Metal3Machine `spec`
+   and to `metadata` on the controlplane Metal3Machine `spec`. Since we don't
+   have any mode set on the Metal3MachineTemplate, Metal3Machines can have
+   different automated cleaning modes set even if they reference the same
+   Metal3MachineTemplate. CAPM3 controller copies cleaning modes from
+   Metal3Machines to their corresponding BareMetalHosts. As such, we end up
+   with two nodes having different cleaning modes regardless of the fact that
+   they reference the same Metal3MachineTemplate.
 
 ![alt](images/object-ref.svg)

--- a/docs/user-guide/src/capm3/data_sources.md
+++ b/docs/user-guide/src/capm3/data_sources.md
@@ -106,8 +106,15 @@ configuration, such as:
 > With other templates the data is mostly just copied over to deployed resources
 > but the networking template supports convenience features like matching NICs
 > (see [NIC matching](### NIC matching). Misconfiguration here can lead to
-> provisioning errors: `"msg"="Reconciler error" "error"="Failed to create secrets: NIC name not found enp1s0"`.
-> For example, see: [CAPM3 Issue #1998](https://github.com/metal3-io/cluster-api-provider-metal3/issues/1998)
+> provisioning errors:
+>
+> ```text
+> "msg"="Reconciler error"
+> "error"="Failed to create secrets: NIC name not found enp1s0".
+> ```
+>
+> For example, see:
+> [CAPM3 Issue #1998](https://github.com/metal3-io/cluster-api-provider-metal3/issues/1998)
 
 The relevant fields in `Metal3Data` are
 

--- a/docs/user-guide/src/capm3/installation_guide.md
+++ b/docs/user-guide/src/capm3/installation_guide.md
@@ -9,11 +9,17 @@ install them yourself.
 
 ## Prerequisites
 
-1. Install `clusterctl`, refer to Cluster API [book](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl) for installation instructions.
-1. Install `kustomize`, refer to official instructions [here](https://kubectl.docs.kubernetes.io/installation/kustomize/).
+1. Install `clusterctl`, refer to Cluster API
+   [book](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl)
+   for installation instructions.
+1. Install `kustomize`, refer to official instructions
+   [here](https://kubectl.docs.kubernetes.io/installation/kustomize/).
 1. Install Ironic, refer to [this page](../ironic/ironic_installation.html).
-1. Install Baremetal Operator, refer to [this page](../bmo/install_baremetal_operator.html).
-1. Install Cluster API core components i.e., core, bootstrap and control-plane providers. This will also install cert-manager, if it is not already installed.
+1. Install Baremetal Operator, refer to
+   [this page](../bmo/install_baremetal_operator.html).
+1. Install Cluster API core components i.e., core, bootstrap and control-plane
+   providers. This will also install cert-manager, if it is not already
+   installed.
 
     ```bash
      clusterctl init --core cluster-api{{#releasetag owner:"kubernetes-sigs" repo:"cluster-api"}} --bootstrap kubeadm{{#releasetag owner:"kubernetes-sigs" repo:"cluster-api"}} \
@@ -22,7 +28,10 @@ install them yourself.
 
 ## With clusterctl
 
-This method is recommended. You can specify the CAPM3 version you want to install by appending a version tag, e.g. `{{#releasetag owner:"metal3-io" repo:"cluster-api-provider-metal3" }}`. If the version is not specified, the latest version available will be installed.
+This method is recommended. You can specify the CAPM3 version you want to
+install by appending a version tag, e.g.
+`{{#releasetag owner:"metal3-io" repo:"cluster-api-provider-metal3" }}`. If the
+version is not specified, the latest version available will be installed.
 
 ```bash
 clusterctl init --infrastructure metal3{{#releasetag owner:"metal3-io" repo:"cluster-api-provider-metal3"}}
@@ -30,7 +39,9 @@ clusterctl init --infrastructure metal3{{#releasetag owner:"metal3-io" repo:"clu
 
 ## With kustomize
 
-To install a specific version, checkout the `github.com/metal3-io/cluster-api-provider-metal3.git` to the tag with the desired version
+To install a specific version, checkout the
+`github.com/metal3-io/cluster-api-provider-metal3.git` to the tag with the
+desired version
 
 ```bash
 git clone https://github.com/metal3-io/cluster-api-provider-metal3.git

--- a/docs/user-guide/src/capm3/introduction.md
+++ b/docs/user-guide/src/capm3/introduction.md
@@ -38,17 +38,31 @@ There are multiple ways to setup a development environment:
 
 ## Getting involved and contributing
 
-Are you interested in contributing to Cluster API Provider Metal3? We, the maintainers and community, would love your suggestions, contributions, and help! Also, the maintainers can be contacted at any time to learn more about how to get involved.
+Are you interested in contributing to Cluster API Provider Metal3? We, the
+maintainers and community, would love your suggestions, contributions, and
+help! Also, the maintainers can be contacted at any time to learn more about
+how to get involved.
 
 To set up your environment checkout the [development environment](#development-environment).
 
-In the interest of getting more new people involved, we tag issues with [good first issue](https://github.com/metal3-io/cluster-api-provider-metal3/labels/good%20first%20issue). These are typically issues that have smaller scope but are good ways to start to get acquainted with the codebase.
+In the interest of getting more new people involved, we tag issues with
+[good first issue](https://github.com/metal3-io/cluster-api-provider-metal3/labels/good%20first%20issue).
+These are typically issues that have smaller scope but are good ways to start
+to get acquainted with the codebase.
 
-We also encourage ALL active community participants to act as if they are maintainers, even if you don’t have "official" write permissions. This is a community effort, we are here to serve the Kubernetes community. If you have an active interest and you want to get involved, you have real power! Don’t assume that the only people who can get things done around here are the "maintainers".
+We also encourage ALL active community participants to act as if they are
+maintainers, even if you don't have "official" write permissions. This is a
+community effort, we are here to serve the Kubernetes community. If you have an
+active interest and you want to get involved, you have real power! Don't assume
+that the only people who can get things done around here are the "maintainers".
 
-We also would love to add more “official” maintainers, so show us what you can do!
+We also would love to add more "official" maintainers, so show us what you can
+do!
 
-All the repositories in the Metal3 project, including the Cluster API Provider Metal3 GitHub repository, use the Kubernetes bot commands. The full list of the commands can be found [here.](https://prow.k8s.io/command-help) Note that some of them might not be implemented in metal3 CI.
+All the repositories in the Metal3 project, including the Cluster API Provider
+Metal3 GitHub repository, use the Kubernetes bot commands. The full list of the
+commands can be found [here.](https://prow.k8s.io/command-help) Note that some
+of them might not be implemented in metal3 CI.
 
 ## Community
 
@@ -63,18 +77,32 @@ There are two different templates to help ensuring that relevant information is 
 
 If you think you have found a bug please follow the instructions below.
 
-- Please spend a small amount of time giving due diligence to the issue tracker. Your issue might be a duplicate.
-- Collect logs from relevant components and make sure to include them in the [bug report](https://github.com/metal3-io/cluster-api-provider-metal3/issues/new?assignees=&labels=&template=bug_report.md) you are going to open.
-- Remember users might be searching for your issue in the future, so please give it a meaningful title to help others.
+- Please spend a small amount of time giving due diligence to the issue
+  tracker. Your issue might be a duplicate.
+- Collect logs from relevant components and make sure to include them in the
+  [bug report](https://github.com/metal3-io/cluster-api-provider-metal3/issues/new?assignees=&labels=&template=bug_report.md)
+  you are going to open.
+- Remember users might be searching for your issue in the future, so please
+  give it a meaningful title to help others.
 - Feel free to reach out to the metal3 [community](#community).
 
 ### Tracking new features
 
-We also use the issue tracker to track features. If you have an idea for a feature, or think you can help Cluster API Provider Metal3 become even more awesome, then follow the steps below.
+We also use the issue tracker to track features. If you have an idea for a
+feature, or think you can help Cluster API Provider Metal3 become even more
+awesome, then follow the steps below.
 
-- Open a [feature request.](https://github.com/metal3-io/cluster-api-provider-metal3/issues/new?template=feature_request.md)
-- Remember users might be searching for your feature request in the future, so please give it a meaningful title to help others.
-- Clearly define the use case, using concrete examples. e.g.: `I type this and cluster-api-provider-metal3 does that.`
-- Some of our larger features will require proposals. If you would like to include a technical design for your feature please open a feature proposal in [metal3-docs](https://github.com/metal3-io/metal3-docs) using [this template](https://github.com/metal3-io/metal3-docs/blob/main/design/_template.md).
+- Open a
+  [feature request.](https://github.com/metal3-io/cluster-api-provider-metal3/issues/new?template=feature_request.md)
+- Remember users might be searching for your feature request in the future, so
+  please give it a meaningful title to help others.
+- Clearly define the use case, using concrete examples. e.g.:
+  `I type this and cluster-api-provider-metal3 does that.`
+- Some of our larger features will require proposals. If you would like to
+  include a technical design for your feature please open a feature proposal in
+  [metal3-docs](https://github.com/metal3-io/metal3-docs) using
+  [this template](https://github.com/metal3-io/metal3-docs/blob/main/design/_template.md).
 
-After the new feature is well understood, and the design agreed upon we can start coding the feature. We would love for you to code it. So please open up a WIP (work in progress) pull request, and happy coding.
+After the new feature is well understood, and the design agreed upon we can
+start coding the feature. We would love for you to code it. So please open up a
+WIP (work in progress) pull request, and happy coding.

--- a/docs/user-guide/src/capm3/label_sync.md
+++ b/docs/user-guide/src/capm3/label_sync.md
@@ -28,7 +28,8 @@ kubectl label baremetalhosts node-0 my-prefix/rack=xyz-123 -n=metal3
 kubectl label baremetalhosts node-0 test.foobar.io/group=abc -n=metal3
 ```
 
-**Note:** Prefixes should be separated from the rest of the label key by **"/"**, e.g. my-prefix/rack, test.foobar.io/xyz
+**Note:** Prefixes should be separated from the rest of the label key by
+**"/"**, e.g. my-prefix/rack, test.foobar.io/xyz
 
 Now label sync controller will apply same labels to corresponding Kubernetes node.
 

--- a/docs/user-guide/src/capm3/node_reuse.md
+++ b/docs/user-guide/src/capm3/node_reuse.md
@@ -1,29 +1,37 @@
 # Node Reuse
 
-This feature brings a possibility of re-using the same BaremetalHosts (referred to as a host later)
-during deprovisioning and provisioning mainly as a part of the rolling upgrade process in the cluster.
+This feature brings a possibility of re-using the same BaremetalHosts (referred
+to as a host later) during deprovisioning and provisioning mainly as a part of
+the rolling upgrade process in the cluster.
 
 ## Importance of scale-in strategy
 
-The logic behind the reusing of the hosts, solely relies on the **scale-in** upgrade strategy utilized by
-Cluster API objects, namely [KubeadmControlPlane](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20191017-kubeadm-based-control-plane.md#rolling-update-strategy) and MachineDeployment.
-During the upgrade process of above resources, the machines owned by KubeadmControlPlane or MachineDeployment are
-removed one-by-one before creating new ones (delete-create method).
-That way, we can fully ensure that, the intended host is reused when the upgrade is kicked in (picked up on the following provisioning for the new machine being created).
+The logic behind the reusing of the hosts, solely relies on the **scale-in**
+upgrade strategy utilized by Cluster API objects, namely
+[KubeadmControlPlane](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20191017-kubeadm-based-control-plane.md#rolling-update-strategy)
+and MachineDeployment. During the upgrade process of above resources, the
+machines owned by KubeadmControlPlane or MachineDeployment are removed
+one-by-one before creating new ones (delete-create method). That way, we can
+fully ensure that, the intended host is reused when the upgrade is kicked in
+(picked up on the following provisioning for the new machine being created).
 
-**Note:** To achieve the desired *delete first and create after* behavior in above-mentioned Cluster API objects,
-user has to modify:
+**Note:** To achieve the desired *delete first and create after* behavior in
+above-mentioned Cluster API objects, user has to modify:
 
-* MaxSurge field in KubeadmControlPlane and set it to 0 with minimum number of 3 control plane machines replicas
-* MaxSurge and MaxUnavailable fields in MachineDeployment set them to 0 & 1 accordingly
+* MaxSurge field in KubeadmControlPlane and set it to 0 with minimum number of
+  3 control plane machines replicas
+* MaxSurge and MaxUnavailable fields in MachineDeployment set them to 0 & 1
+  accordingly
 
-On the contrary, if the scale-out strategy is utilized by CAPI objects during the upgrade, usually create-swap-delete
-method is followed by CAPI objects, where new machine is created first and new host is picked up for that
-machine, breaking the node reuse logic right at the beginning of the upgrade process.
+On the contrary, if the scale-out strategy is utilized by CAPI objects during
+the upgrade, usually create-swap-delete method is followed by CAPI objects,
+where new machine is created first and new host is picked up for that machine,
+breaking the node reuse logic right at the beginning of the upgrade process.
 
 ## Workflow
 
-Metal3MachineTemplate (M3MT) Custom Resource is the object responsible for enabling of the node reuse feature.
+Metal3MachineTemplate (M3MT) Custom Resource is the object responsible for
+enabling of the node reuse feature.
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -39,12 +47,27 @@ spec:
       ...
 ```
 
-There could be two Metal3MachineTemplate objects, one referenced by KubeadmControlPlane for control plane nodes, and the other by MachineDeployment for worker node. Before performing an upgrade, user must set `nodeReuse` field to **true** in the desired Metal3MachineTemplate object where hosts targeted to be reused. If left unchanged, by default, `nodeReuse` field is set to **false** resulting in no host reusing being performed in the workflow. If you would like to know more about the internals of controller logic, please check the original proposal for the feature [here](https://github.com/metal3-io/metal3-docs/blob/main/design/cluster-api-provider-metal3/node_reuse.md)
+There could be two Metal3MachineTemplate objects, one referenced by
+KubeadmControlPlane for control plane nodes, and the other by MachineDeployment
+for worker node. Before performing an upgrade, user must set `nodeReuse` field
+to **true** in the desired Metal3MachineTemplate object where hosts targeted to
+be reused. If left unchanged, by default, `nodeReuse` field is set to **false**
+resulting in no host reusing being performed in the workflow. If you would like
+to know more about the internals of controller logic, please check the original
+proposal for the feature
+[here](https://github.com/metal3-io/metal3-docs/blob/main/design/cluster-api-provider-metal3/node_reuse.md)
 
-Once `nodeReuse` field is set to **true**, user has to make sure that scale-in feature is enabled as suggested above, and proceed with updating the desired fields in KubeadmControlPlane or MachineDeployment to start a rolling upgrade.
+Once `nodeReuse` field is set to **true**, user has to make sure that scale-in
+feature is enabled as suggested above, and proceed with updating the desired
+fields in KubeadmControlPlane or MachineDeployment to start a rolling upgrade.
 
-**Note:** If you are creating a new Metal3MachineTemplate object (for control-plane or worker), rather than using the existing one
-created while provisioning, please make sure to reference it from the corresponding Cluster API object (KubeadmControlPlane or MachineDeployment). Also keep in mind that, already provisioned Metal3Machines were created from the old Metal3MachineTemplate
-and they consume existing hosts, meaning even though `nodeReuse` field is set to **true** in the new Metal3MachineTemplate,
-it would have no effect. To use newly Metal3MachineTemplate in the workflow, user has to reprovision the nodes, which
-should result in using new Metal3MachineTemplate referenced in Cluster API object and Metal3Machine created out of it.
+**Note:** If you are creating a new Metal3MachineTemplate object (for
+control-plane or worker), rather than using the existing one created while
+provisioning, please make sure to reference it from the corresponding Cluster
+API object (KubeadmControlPlane or MachineDeployment). Also keep in mind that,
+already provisioned Metal3Machines were created from the old
+Metal3MachineTemplate and they consume existing hosts, meaning even though
+`nodeReuse` field is set to **true** in the new Metal3MachineTemplate, it would
+have no effect. To use newly Metal3MachineTemplate in the workflow, user has to
+reprovision the nodes, which should result in using new Metal3MachineTemplate
+referenced in Cluster API object and Metal3Machine created out of it.

--- a/docs/user-guide/src/capm3/pivoting.md
+++ b/docs/user-guide/src/capm3/pivoting.md
@@ -4,24 +4,30 @@
 
 ## What is pivoting
 
-Cluster API Provider Metal3 (CAPM3) implements support for CAPI's 'move/pivoting' feature.
+Cluster API Provider Metal3 (CAPM3) implements support for CAPI's
+'move/pivoting' feature.
 
-CAPI Pivoting feature is a process of moving the provider components and declared Cluster API resources from a source
-management cluster to a target management cluster by using the `clusterctl` functionality called "move".
-More information about the general CAPI "move" functionality can be found [here](https://cluster-api.sigs.k8s.io/clusterctl/commands/move.html).
+CAPI Pivoting feature is a process of moving the provider components and
+declared Cluster API resources from a source management cluster to a target
+management cluster by using the `clusterctl` functionality called "move". More
+information about the general CAPI "move" functionality can be found
+[here](https://cluster-api.sigs.k8s.io/clusterctl/commands/move.html).
 
-In Metal3, pivoting is performed by using the CAPI `clusterctl` tool provided by Cluster-API project. `clusterctl` recognizes pivoting as move.
-During the pivot process `clusterctl` pauses any reconciliation of CAPI objects and this gets propagated to CAPM3 objects as well.
-Once all the objects are paused, the objects are created on the other side on the target cluster and deleted from the
-bootstrap cluster.
+In Metal3, pivoting is performed by using the CAPI `clusterctl` tool provided
+by Cluster-API project. `clusterctl` recognizes pivoting as move. During the
+pivot process `clusterctl` pauses any reconciliation of CAPI objects and this
+gets propagated to CAPM3 objects as well. Once all the objects are paused, the
+objects are created on the other side on the target cluster and deleted from
+the bootstrap cluster.
 
 ## Prerequisite
 
 1. **It is mandatory to use `clusterctl` for both the bootstrap and target cluster.**
 
    If the provider components are not installed using `clusterctl`, it will not
-   be able to identify the objects to move.  Initializing the cluster using
-   `clusterctl` essentially adds the following labels in the CRDs of each related object.
+   be able to identify the objects to move. Initializing the cluster using
+   `clusterctl` essentially adds the following labels in the CRDs of each
+   related object.
 
    ```yaml
    labels:
@@ -29,33 +35,33 @@ bootstrap cluster.
    - cluster.x-k8s.io/provider: "<provider-name>"
    ```
 
-   So if the clusters are not initialized using `clusterctl`, all the CRDS of the
-   objects to be moved to target cluster needs to have these labels both in
+   So if the clusters are not initialized using `clusterctl`, all the CRDS of
+   the objects to be moved to target cluster needs to have these labels both in
    bootstrap cluster and target cluster before performing the move.
 
-   **Note**: This is not recommended, since
-   the way `clusterctl` identifies objects to manage might change in the future, so
-   it's always safe to install CRDs and controllers through the `clusterctl init` sub-command.
+   **Note**: This is not recommended, since the way `clusterctl` identifies
+   objects to manage might change in the future, so it's always safe to install
+   CRDs and controllers through the `clusterctl init` sub-command.
 
 1. **BareMetalHost objects have correct status annotation.**
 
-   Since BareMetalHost (BMH) _status_ holds important information regarding the BMH itself, BMH with
-   status has to be moved and it has to be reconstructed with correct status in
-   target  cluster before it is being reconciled. This is now done through BMH
-   status annotation in [BMO](../bmo/introduction.md).
+   Since BareMetalHost (BMH) _status_ holds important information regarding the
+   BMH itself, BMH with status has to be moved and it has to be reconstructed
+   with correct status in target cluster before it is being reconciled. This is
+   now done through BMH status annotation in [BMO](../bmo/introduction.md).
 
 1. **Maintain connectivity towards provisioning network.**
 
    Baremetal machines boot over a network with a DHCP server. This requires
    maintaining a fixed IP end points towards the provisioning network. This is
    achieved through _keepalived_. A new container is added namely
-   _ironic-endpoint-keepalived_ in the ironic deployment which maintains the Ironic Endpoint using
-   keepalived. The motivation behind maintaining Ironic Endpoint with Keepalived
-   is to ensure that the Ironic Endpoint IP is also passed onto the target
-   cluster control plane. This also guarantees that once moving is done and the
-   management cluster is taken down, target cluster controlplane can re-claim
-   the Ironic endpoint IP through keepalived. The end goal is to make Ironic
-   endpoint reachable in the target cluster.
+   _ironic-endpoint-keepalived_ in the ironic deployment which maintains the
+   Ironic Endpoint using keepalived. The motivation behind maintaining Ironic
+   Endpoint with Keepalived is to ensure that the Ironic Endpoint IP is also
+   passed onto the target cluster control plane. This also guarantees that once
+   moving is done and the management cluster is taken down, target cluster
+   controlplane can re-claim the Ironic endpoint IP through keepalived. The end
+   goal is to make Ironic endpoint reachable in the target cluster.
 
 1. **BMO is deployed as part of CAPM3.**
 
@@ -78,22 +84,22 @@ The following requirements are essential for the move process to run
 successfully:
 
 1. The move process should be done when the BMHs are in a steady state. BMHs
-   should not be moved while any operation is on-going i.e. BMH is in provisioning
-   state. This will result in failure since the interaction between IPA and Ironic
-   gets broken and as a result Ironic's database might not be repopulated and
-   eventually the cluster will end up in an erroneous state. Moreover, the IP of
-   the BMH might change after the move and the DHCP-leases from the management
-   cluster are not moved to target cluster.
+   should not be moved while any operation is on-going i.e. BMH is in
+   provisioning state. This will result in failure since the interaction between
+   IPA and Ironic gets broken and as a result Ironic's database might not be
+   repopulated and eventually the cluster will end up in an erroneous state.
+   Moreover, the IP of the BMH might change after the move and the DHCP-leases
+   from the management cluster are not moved to target cluster.
 
 2. Before the move process is initialized, it is important to delete the Ironic
    pod/Ironic containers. If Ironic is deployed in cluster the deployment is named
    `metal3-ironic`, if it is deployed locally outside the cluster then the user
    has to make sure that all of the ironic related containers are correctly deleted.
-   If Ironic is not deleted before move, the old Ironic might interfere with the operations of
-   the new Ironic deployed in target cluster since the database of the first Ironic
-   instance is not cleaned when the BMHs are moved. Also there would be two dnsmasq
-   existent in the deployment if there would be two Ironic deployment which is
-   undesirable.
+   If Ironic is not deleted before move, the old Ironic might interfere with
+   the operations of the new Ironic deployed in target cluster since the
+   database of the first Ironic instance is not cleaned when the BMHs are moved.
+   Also there would be two dnsmasq existent in the deployment if there would be
+   two Ironic deployment which is undesirable.
 
 3. The provisioning bridge where the `ironic-endpoint-IP` is supposed to be
    attached to should have a static IP assignment on it before the Ironic
@@ -116,10 +122,10 @@ cluster used to provision a target management cluster.
 
 This can now be achieved with the following procedure:
 
-1. Create a temporary bootstrap cluster, the temporary bootstrap cluster
- could be created tools like e.g. using Kind or Minikube using and after the bootstrap cluster
- is up and running then the CAPI and provider components can be installed with `clusterctl` to
- the bootstrap cluster.
+1. Create a temporary bootstrap cluster, the temporary bootstrap cluster could
+   be created tools like e.g. using Kind or Minikube using and after the
+   bootstrap cluster is up and running then the CAPI and provider components
+   can be installed with `clusterctl` to the bootstrap cluster.
 
 2. Install Ironic components, namely: ironic, ironic-endpoint-keepalived, httpd
    and dnsmasq.
@@ -148,10 +154,10 @@ This can now be achieved with the following procedure:
 5. Wait for the target management cluster to be up and running and once it is up
  get the kubeconfig for the new target management cluster.
 
-6. Use the new cluster’s kubeconfig to install the ironic-components in the
+6. Use the new cluster's kubeconfig to install the ironic-components in the
  target cluster.
 
-7. Use `clusterctl` init with the new cluster’s kubeconfig to install the provider
+7. Use `clusterctl` init with the new cluster's kubeconfig to install the provider
  components.
 
     Example:

--- a/docs/user-guide/src/capm3/remediaton.md
+++ b/docs/user-guide/src/capm3/remediaton.md
@@ -1,22 +1,69 @@
 # Remediation Controller and MachineHealthCheck
 
-The Cluster API includes the [remediation](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking.html) feature that implements an automated health checking of k8s nodes. It deletes unhealthy Machine and replaces with a healthy one. This approach can be challenging with cloud providers that are using hardware based clusters because of slower (re)provisioning of unhealthy Machines. To overcome this situation, CAPI remediation feature was extended to plug-in provider specific external remediation. It is also possible to plug-in Metal3 specific remediation strategies to remediate unhealthy nodes. In this case, the Cluster API MHC finds unhealthy nodes while the CAPM3 Remediation Controller remediates those unhealthy nodes.
+The Cluster API includes the
+[remediation](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking.html)
+feature that implements an automated health checking of k8s nodes. It deletes
+unhealthy Machine and replaces with a healthy one. This approach can be
+challenging with cloud providers that are using hardware based clusters because
+of slower (re)provisioning of unhealthy Machines. To overcome this situation,
+CAPI remediation feature was extended to plug-in provider specific external
+remediation. It is also possible to plug-in Metal3 specific remediation
+strategies to remediate unhealthy nodes. In this case, the Cluster API MHC
+finds unhealthy nodes while the CAPM3 Remediation Controller remediates those
+unhealthy nodes.
 
 ## CAPI Remediation
 
-A MachineHealthCheck is a Cluster API resource, which allows users to define conditions under which Machines within a Cluster should be considered unhealthy. Users can also specify a timeout for each of the conditions that they define to check on the Machine’s Node. If any of these conditions are met for the duration of the timeout, the Machine will be remediated. CAPM3 will use the MachineHealthCheck to create remediation requests based on Metal3RemediationTemplate and Metal3Remediation CRDs to plug-in remediation solution. For more info, please read the [CAPI MHC](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking.html)link.
+A MachineHealthCheck is a Cluster API resource, which allows users to define
+conditions under which Machines within a Cluster should be considered
+unhealthy. Users can also specify a timeout for each of the conditions that
+they define to check on the Machine's Node. If any of these conditions are met
+for the duration of the timeout, the Machine will be remediated. CAPM3 will use
+the MachineHealthCheck to create remediation requests based on
+Metal3RemediationTemplate and Metal3Remediation CRDs to plug-in remediation
+solution. For more info, please read the
+[CAPI MHC](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking.html)
+link.
 
 ## External Remediation
 
-External remediation provides remediation solutions other than deleting unhealthy Machine and creating healthy one. Environments consisting of hardware based clusters are slower to (re)provision unhealthy Machines. So there is a growing need for a remediation flow that includes external remediation which can significantly reduce the remediation process time. Normally the conditions based remediation doesn’t offer any other remediation than deleting an unhealthy Machine and replacing it with a new one. Other environments and vendors can also have specific remediation requirements, so there is a need to provide a generic mechanism for implementing custom remediation logic. External remediation integrates with CAPI MHC and support remediation based on power cycling the underlying hardware. It supports the use of BMO reboot API and CAPM3 unhealthy annotation as part of the automated remediation cycle. It is a generic mechanism for supporting externally provided custom remediation strategies. If no value for externalRemediationTemplate is defined for the MachineHealthCheck CR, the condition-based flow is continued. For more info: [External Remediation proposal](https://github.com/kubernetes-sigs/cluster-api/pull/3190/files)
+External remediation provides remediation solutions other than deleting
+unhealthy Machine and creating healthy one. Environments consisting of hardware
+based clusters are slower to (re)provision unhealthy Machines. So there is a
+growing need for a remediation flow that includes external remediation which
+can significantly reduce the remediation process time. Normally the conditions
+based remediation doesn't offer any other remediation than deleting an
+unhealthy Machine and replacing it with a new one. Other environments and
+vendors can also have specific remediation requirements, so there is a need to
+provide a generic mechanism for implementing custom remediation logic. External
+remediation integrates with CAPI MHC and support remediation based on power
+cycling the underlying hardware. It supports the use of BMO reboot API and
+CAPM3 unhealthy annotation as part of the automated remediation cycle. It is a
+generic mechanism for supporting externally provided custom remediation
+strategies. If no value for externalRemediationTemplate is defined for the
+MachineHealthCheck CR, the condition-based flow is continued. For more info:
+[External Remediation proposal](https://github.com/kubernetes-sigs/cluster-api/pull/3190/files)
 
 ## Metal3 Remediation
 
-The CAPM3 remediation controller reconciles Metal3Remediation objects created by CAPI MachineHealthCheck. It locates a Machine with the same name as the Metal3Remediation object and uses BMO and CAPM3 APIs to remediate associated unhealthy node. The remediation controller supports a reboot strategy specified in the Metal3Remediation CRD and uses the same object to store states of the current remediation cycle. The reboot strategy consists of three steps: power off the Machine, apply a [Out-of-Service Taint](https://kubernetes.io/docs/reference/labels-annotations-taints/#node-kubernetes-io-out-of-service) on the related Node, and power the Machine on again. Applying the Out-of-Service Taint is part of the (GA In Kubernetes 1.28) [Non-Graceful node shutdown](https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/#non-graceful-node-shutdown) handling which allows stateful workloads to restart on a different node.
+The CAPM3 remediation controller reconciles Metal3Remediation objects created
+by CAPI MachineHealthCheck. It locates a Machine with the same name as the
+Metal3Remediation object and uses BMO and CAPM3 APIs to remediate associated
+unhealthy node. The remediation controller supports a reboot strategy specified
+in the Metal3Remediation CRD and uses the same object to store states of the
+current remediation cycle. The reboot strategy consists of three steps: power
+off the Machine, apply a
+[Out-of-Service Taint](https://kubernetes.io/docs/reference/labels-annotations-taints/#node-kubernetes-io-out-of-service)
+on the related Node, and power the Machine on again. Applying the Out-of-Service
+Taint is part of the (GA In Kubernetes 1.28)
+[Non-Graceful node shutdown](https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/#non-graceful-node-shutdown)
+handling which allows stateful workloads to restart on a different node.
 
 ### Enable remediation for worker nodes
 
-Machines managed by a MachineSet (as identified by the `nodepool` label) can be remediated. Here is an example MachineHealthCheck and Metal3Remediation for worker nodes:
+Machines managed by a MachineSet (as identified by the `nodepool` label) can be
+remediated. Here is an example MachineHealthCheck and Metal3Remediation for
+worker nodes:
 
 ```yaml
 
@@ -79,7 +126,12 @@ spec:
 
 ### Enable remediation for control plane nodes
 
-Machines managed by a KubeadmControlPlane are remediated according to the [KubeadmControlPlane proposal](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20191017-kubeadm-based-control-plane.md#remediation-using-delete-and-recreate). It is necessary to have at least 2 control plane machines in order to use remediation feature. Control plane nodes are identified by the `cluster.x-k8s.io/control-plane` label. Here is an example MachineHealthCheck and Metal3Remediation for control plane nodes:
+Machines managed by a KubeadmControlPlane are remediated according to the
+[KubeadmControlPlane proposal](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20191017-kubeadm-based-control-plane.md#remediation-using-delete-and-recreate).
+It is necessary to have at least 2 control plane machines in order to use
+remediation feature. Control plane nodes are identified by the
+`cluster.x-k8s.io/control-plane` label. Here is an example MachineHealthCheck
+and Metal3Remediation for control plane nodes:
 
 ```yaml
 
@@ -130,10 +182,14 @@ spec:
 
 ## Limitations and caveats of Metal3 remediation
 
-* Machines owned by a MachineSet or a KubeadmControlPlane can be remediated by a MachineHealthCheck
+* Machines owned by a MachineSet or a KubeadmControlPlane can be remediated by
+  a MachineHealthCheck
 
-* If the Node for a Machine is removed from the cluster, CAPI MachineHealthCheck will consider this Machine unhealthy and remediates it immediately
+* If the Node for a Machine is removed from the cluster, CAPI MachineHealthCheck
+  will consider this Machine unhealthy and remediates it immediately
 
-* If there is no Node joins the cluster for a Machine after the ```NodeStartupTimeout```, the Machine will be remediated
+* If there is no Node joins the cluster for a Machine after the
+  `NodeStartupTimeout`, the Machine will be remediated
 
-* If a Machine fails for any reason and the ```FailureReason``` is set, the Machine will be remediated immediately
+* If a Machine fails for any reason and the `FailureReason` is set, the Machine
+  will be remediated immediately

--- a/docs/user-guide/src/developer_environment/tryit.md
+++ b/docs/user-guide/src/developer_environment/tryit.md
@@ -2,7 +2,8 @@
 
 <!-- cSpell:ignore fcos -->
 
- Ready to start taking steps towards your first experience with metal3? Follow these commands to get started!
+ Ready to start taking steps towards your first experience with metal3? Follow
+ these commands to get started!
 
 - [1. Environment Setup](#1-environment-setup)
    - [1.1. Prerequisites](#11-prerequisites)
@@ -24,9 +25,9 @@
 ## 1. Environment Setup
 
 > **_info:_** "Naming"
-> For the v1alpha3 release, the Cluster API provider for Metal3 was renamed from
-> Cluster API provider BareMetal (CAPBM) to Cluster API provider Metal3 (CAPM3). Hence,
-> from v1alpha3 onwards it is Cluster API provider Metal3.
+> For the v1alpha3 release, the Cluster API provider for Metal3 was renamed
+> from Cluster API provider BareMetal (CAPBM) to Cluster API provider Metal3
+> (CAPM3). Hence, from v1alpha3 onwards it is Cluster API provider Metal3.
 
 ### 1.1. Prerequisites
 
@@ -51,7 +52,8 @@ For execution with VMs
 ```
 
 - Save and exit
-- Manually **enable nested virtualization** if you don't have it enabled in your system
+- Manually **enable nested virtualization** if you don't have it enabled in
+  your system
 
 ```console
   # To enable nested virtualization
@@ -80,9 +82,16 @@ For execution with VMs
 ### 1.2. Setup
 
 > **_info:_** "Information"
-> If you need detailed information regarding the process of creating a Metal³ emulated environment using metal3-dev-env, it is worth taking a look at the blog post ["A detailed walkthrough of the Metal³ development environment"](https://metal3.io/blog/2020/02/18/metal3-dev-env-install-deep-dive.html).
+> If you need detailed information regarding the process of creating a Metal3
+> emulated environment using metal3-dev-env, it is worth taking a look at the
+> blog post
+> ["A detailed walkthrough of the Metal3 development environment"](https://metal3.io/blog/2020/02/18/metal3-dev-env-install-deep-dive.html).
 
-This is a high-level architecture of the Metal³-dev-env. Note that for an Ubuntu-based setup, either Kind or Minikube can be used to instantiate an ephemeral cluster, while for a CentOS-based setup, only Minikube is currently supported. The ephemeral cluster creation tool can be manipulated with the EPHEMERAL_CLUSTER environment variable.
+This is a high-level architecture of the Metal3-dev-env. Note that for an
+Ubuntu-based setup, either Kind or Minikube can be used to instantiate an
+ephemeral cluster, while for a CentOS-based setup, only Minikube is currently
+supported. The ephemeral cluster creation tool can be manipulated with the
+EPHEMERAL_CLUSTER environment variable.
 
  ![metal3-dev-env image](https://raw.githubusercontent.com/metal3-io/metal3-docs/main/images/metal3-dev-env.png)
 
@@ -100,12 +109,14 @@ The `Makefile` runs a series of scripts, described here:
 - `02_configure_host.sh` - Creates a set of VMs that will be managed as if they
   were bare metal hosts. It also downloads some images needed for Ironic.
 
-- `03_launch_mgmt_cluster.sh` - Launches a management cluster using `minikube` or `kind`
-  and runs the `baremetal-operator` on that cluster.
+- `03_launch_mgmt_cluster.sh` - Launches a management cluster using `minikube`
+  or `kind` and runs the `baremetal-operator` on that cluster.
 
-- `04_verify.sh` - Runs a set of tests that verify that the deployment was completed successfully.
+- `04_verify.sh` - Runs a set of tests that verify that the deployment was
+  completed successfully.
 
-When the environment setup is completed, you should be able to see the `BareMetalHost` (`bmh`) objects in the Ready state.
+When the environment setup is completed, you should be able to see the
+`BareMetalHost` (`bmh`) objects in the Ready state.
 
 ### 1.3. Tear Down
 
@@ -123,24 +134,31 @@ To tear down the environment, run
 >
 > ```console
 > error: failed to connect to the hypervisor \
-> error: Failed to connect socket to '/var/run/libvirt/libvirt-sock':  Permission denied
+> error: Failed to connect socket to '/var/run/libvirt/libvirt-sock': \
+> Permission denied
 > ```
 >
-> You may need to log out then log in again, and run `make clean` and `make` again.
+> You may need to log out then log in again, and run `make clean` and `make`
+> again.
 
 ### 1.4. Using Custom Image
 
-Whether you want to run target cluster Nodes with your own image, you can override the three following variables: `IMAGE_NAME`,
-`IMAGE_LOCATION`, `IMAGE_USERNAME`. If the requested image with the name `IMAGE_NAME` does not
-exist in the `IRONIC_IMAGE_DIR` (/opt/metal3-dev-env/ironic/html/images) folder, then it will be automatically
-downloaded from the `IMAGE_LOCATION` value configured.
+Whether you want to run target cluster Nodes with your own image, you can
+override the three following variables: `IMAGE_NAME`, `IMAGE_LOCATION`,
+`IMAGE_USERNAME`. If the requested image with the name `IMAGE_NAME` does not
+exist in the `IRONIC_IMAGE_DIR` (/opt/metal3-dev-env/ironic/html/images) folder,
+then it will be automatically downloaded from the `IMAGE_LOCATION` value
+configured.
 
 ### 1.5. Setting environment variables
 
 > **_info:_** "Environment variables"
-> More information about the specific environment variables used to set up metal3-dev-env can be found [here](https://github.com/metal3-io/metal3-dev-env/blob/main/vars.md).
+> More information about the specific environment variables used to set up
+> metal3-dev-env can be found
+> [here](https://github.com/metal3-io/metal3-dev-env/blob/main/vars.md).
 
-To set environment variables persistently, export them from the configuration file used by metal³-dev-env scripts:
+To set environment variables persistently, export them from the configuration
+file used by metal3-dev-env scripts:
 
 ```bash
  cp config_example.sh config_$(whoami).sh
@@ -154,18 +172,27 @@ To set environment variables persistently, export them from the configuration fi
 This environment creates a set of VMs to manage as if they were bare metal
 hosts.
 
-There are two different host OSs that the metal3-dev-env setup process is tested on.
+There are two different host OSs that the metal3-dev-env setup process is
+tested on.
 
-1. Host VM/Server on CentOS, while the target can be Ubuntu or CentOS, Cirros, or FCOS.
-2. Host VM/Server on Ubuntu, while the target can be Ubuntu or CentOS, Cirros, or FCOS.
+1. Host VM/Server on CentOS, while the target can be Ubuntu or CentOS, Cirros,
+   or FCOS.
+2. Host VM/Server on Ubuntu, while the target can be Ubuntu or CentOS, Cirros,
+   or FCOS.
 
-The way the k8s cluster is running in the above two scenarios is different. For CentOS `minikube` cluster is used as the source cluster, for Ubuntu, a `kind` cluster is being created.
-As such, when the host (where the `make` command was issued) OS is CentOS, there should be three libvirt VMs and one of them should be a `minikube` VM.
+The way the k8s cluster is running in the above two scenarios is different. For
+CentOS `minikube` cluster is used as the source cluster, for Ubuntu, a `kind`
+cluster is being created. As such, when the host (where the `make` command was
+issued) OS is CentOS, there should be three libvirt VMs and one of them should
+be a `minikube` VM.
 
-In case the host OS is Ubuntu, the k8s source cluster is created by using `kind`, so in this case the `minikube` VM won't be present.
+In case the host OS is Ubuntu, the k8s source cluster is created by using
+`kind`, so in this case the `minikube` VM won't be present.
 
-To configure what tool should be used for creating source k8s cluster the `EPHEMERAL_CLUSTER` environment variable is responsible.
-The `EPHEMERAL_CLUSTER` is configured to build `minikube` cluster by default on a CentOS host and `kind` cluster on a Ubuntu host.
+To configure what tool should be used for creating source k8s cluster the
+`EPHEMERAL_CLUSTER` environment variable is responsible. The `EPHEMERAL_CLUSTER`
+is configured to build `minikube` cluster by default on a CentOS host and
+`kind` cluster on a Ubuntu host.
 
 VMs can be listed using `virsh` cli tool.
 
@@ -180,8 +207,8 @@ $ sudo virsh list
  2     node_1     running
 ```
 
-In case the `EPHEMERAL_CLUSTER` environment variable is set to `minikube` the list of
-running virtual machines will look like this:
+In case the `EPHEMERAL_CLUSTER` environment variable is set to `minikube` the
+list of running virtual machines will look like this:
 
 ```console
 $ sudo virsh list
@@ -326,13 +353,17 @@ This section describes how to trigger the provisioning of a cluster and hosts vi
 `Machine` objects as part of the Cluster API integration. This uses Cluster API
 [v1beta1](https://github.com/kubernetes-sigs/cluster-api/tree/v1.0.2) and
 assumes that metal3-dev-env is deployed with the environment variable
-**CAPM3_VERSION** set to **v1beta1**. This is the default behavior. The v1beta1 deployment can be done with
-Ubuntu 22.04 or Centos 9 Stream target host images. Please make sure to meet
-[resource requirements](#11-prerequisites) for successful deployment:
+**CAPM3_VERSION** set to **v1beta1**. This is the default behavior. The v1beta1
+deployment can be done with Ubuntu 22.04 or Centos 9 Stream target host images.
+Please make sure to meet [resource requirements](#11-prerequisites) for
+successful deployment:
 
-See [support version](https://github.com/metal3-io/cluster-api-provider-metal3#compatibility-with-cluster-api) for more on CAPI compatibility
+See
+[support version](https://github.com/metal3-io/cluster-api-provider-metal3#compatibility-with-cluster-api)
+for more on CAPI compatibility
 
-The following scripts can be used to provision a cluster, controlplane node and worker node.
+The following scripts can be used to provision a cluster, controlplane node and
+worker node.
 
 ```console
 ./tests/scripts/provision/cluster.sh
@@ -341,10 +372,11 @@ The following scripts can be used to provision a cluster, controlplane node and 
 ```
 
 At this point, the `Machine` actuator will respond and try to claim a
-`BareMetalHost` for this `Metal3Machine`. You can check the logs of the actuator.
+`BareMetalHost` for this `Metal3Machine`. You can check the logs of the
+actuator.
 
-First, check the names of the pods running in the `baremetal-operator-system` namespace and the output should be something similar
-to this:
+First, check the names of the pods running in the `baremetal-operator-system`
+namespace and the output should be something similar to this:
 
 ```console
 $ kubectl -n baremetal-operator-system get pods
@@ -352,8 +384,9 @@ NAME                                                    READY   STATUS    RESTAR
 baremetal-operator-controller-manager-5fd4fb6c8-c9prs   2/2     Running   0          71m
 ```
 
-In order to get the logs of the actuator the logs of the baremetal-operator-controller-manager instance have to be queried with
-the following command:
+In order to get the logs of the actuator the logs of the
+baremetal-operator-controller-manager instance have to be queried with the
+following command:
 
 ```console
 $ kubectl logs -n baremetal-operator-system pod/baremetal-operator-controller-manager-5fd4fb6c8-c9prs -c manager
@@ -362,12 +395,12 @@ $ kubectl logs -n baremetal-operator-system pod/baremetal-operator-controller-ma
 ...
 ```
 
-Keep in mind that the suffix hashes e.g. `5fd4fb6c8-c9prs` are automatically generated and change in case of a different
-deployment.
+Keep in mind that the suffix hashes e.g. `5fd4fb6c8-c9prs` are automatically
+generated and change in case of a different deployment.
 
-If you look at the yaml representation of the `Metal3Machine` object, you will see a
-new annotation that identifies which `BareMetalHost` was chosen to satisfy this
-`Metal3Machine` request.
+If you look at the yaml representation of the `Metal3Machine` object, you will
+see a new annotation that identifies which `BareMetalHost` was chosen to
+satisfy this `Metal3Machine` request.
 
 First list the `Metal3Machine` objects present in the `metal3` namespace:
 
@@ -378,8 +411,9 @@ test1-controlplane-jjd9l   metal3://d4848820-55fd-410a-b902-5b2122dd206c   true 
 test1-workers-bx4wp        metal3://ee337588-be96-4d5b-95b9-b7375969debd   true    test1
 ```
 
-Based on the name of the `Metal3Machine` objects you can check the yaml representation of the object and
-see from its annotation which `BareMetalHost` was chosen.
+Based on the name of the `Metal3Machine` objects you can check the yaml
+representation of the object and see from its annotation which `BareMetalHost`
+was chosen.
 
 ```console
 $ kubectl get metal3machine test1-workers-bx4wp -n metal3 -o yaml
@@ -390,7 +424,8 @@ $ kubectl get metal3machine test1-workers-bx4wp -n metal3 -o yaml
 ```
 
 You can also see in the list of `BareMetalHosts` that one of the hosts is now
-provisioned and associated with a `Metal3Machines` by looking at the `CONSUMER` output column of the following command:
+provisioned and associated with a `Metal3Machines` by looking at the `CONSUMER`
+output column of the following command:
 
 ```console
 $ kubectl get baremetalhosts -n metal3
@@ -399,8 +434,8 @@ node-0   provisioned   test1-controlplane-jjd9l   true             122m
 node-1   provisioned   test1-workers-bx4wp        true             122m
 ```
 
-It is also possible to check which `Metal3Machine` serves as the infrastructure for the ClusterAPI `Machine`
-objects.
+It is also possible to check which `Metal3Machine` serves as the infrastructure
+for the ClusterAPI `Machine` objects.
 
 First list the `Machine` objects:
 
@@ -411,8 +446,8 @@ test1-6d8cc5965f-wvzms   test1     test1-6d8cc5965f-wvzms   metal3://7f51f14b-77
 test1-nphjx              test1     test1-nphjx              metal3://14fbcd25-4d09-4aca-9628-a789ba3e175c   Running   55m   v1.22.3
 ```
 
-As a next step you can check what serves as the infrastructure backend for e.g. `test1-6d8cc5965f-wvzms` `Machine`
-object:
+As a next step you can check what serves as the infrastructure backend for e.g.
+`test1-6d8cc5965f-wvzms` `Machine` object:
 
 ```console
 $ kubectl get machine test1-6d8cc5965f-wvzms -n metal3 -o yaml
@@ -426,14 +461,14 @@ $ kubectl get machine test1-6d8cc5965f-wvzms -n metal3 -o yaml
 ...
 ```
 
-Based on the result of the query `test1-6d8cc5965f-wvzms` ClusterAPI `Machine` object is backed by
-`test1-workers-bx4wp` `Metal3Machine` object.
+Based on the result of the query `test1-6d8cc5965f-wvzms` ClusterAPI `Machine`
+object is backed by `test1-workers-bx4wp` `Metal3Machine` object.
 
 You should be able to ssh into your host once provisioning is completed.
 The default username for both CentOS & Ubuntu images is `metal3`.
 For the IP address, you can either use the API endpoint IP of the target cluster
-which is - `192.168.111.249` by default or use the predictable IP address of the first
-master node - `192.168.111.100`.
+which is - `192.168.111.249` by default or use the predictable IP address of
+the first master node - `192.168.111.100`.
 
 ```console
  ssh metal3@192.168.111.249
@@ -441,7 +476,9 @@ master node - `192.168.111.100`.
 
 ### 2.3. Deprovision Cluster and Machines
 
-Deprovisioning of the target cluster is done just by deleting `Cluster` and `Machine` objects or by executing the de-provisioning scripts in reverse order than provisioning:
+Deprovisioning of the target cluster is done just by deleting `Cluster` and
+`Machine` objects or by executing the de-provisioning scripts in reverse order
+than provisioning:
 
 ```console
 ./tests/scripts/deprovision/worker.sh
@@ -449,16 +486,23 @@ Deprovisioning of the target cluster is done just by deleting `Cluster` and `Mac
 ./tests/scripts/deprovision/cluster.sh
 ```
 
-Note that you can easily de-provision worker Nodes by decreasing the number of replicas in the `MachineDeployment` object created when executing the `provision/worker.sh` script:
+Note that you can easily de-provision worker Nodes by decreasing the number of
+replicas in the `MachineDeployment` object created when executing the
+`provision/worker.sh` script:
 
 ```console
 kubectl scale machinedeployment test1 -n metal3 --replicas=0
 ```
 
 > warning "Warning"
-> control-plane and cluster are very tied together. This means that you are not able to de-provision the control-plane of a cluster and then provision a new one within the same cluster. Therefore, in case you want to de-provision the control-plane you need to **de-provision the cluster** as well and provision both again.
+> control-plane and cluster are very tied together. This means that you are not
+> able to de-provision the control-plane of a cluster and then provision a new
+> one within the same cluster. Therefore, in case you want to de-provision the
+> control-plane you need to **de-provision the cluster** as well and provision
+> both again.
 
-Below, it is shown how the de-provisioning can be executed in a more manual way by just deleting the proper Custom Resources (CR).
+Below, it is shown how the de-provisioning can be executed in a more manual way
+by just deleting the proper Custom Resources (CR).
 
 The order of deletion is:
 
@@ -468,8 +512,10 @@ The order of deletion is:
 4. Metal3Machine objects of the control plane
 5. The cluster object
 
-An additional detail is that the `Machine` object `test1-workers-bx4wp` is controlled by the `test1` `MachineDeployment`
-the object thus in order to avoid reprovisioning of the `Machine` object the `MachineDeployment` has to be deleted instead of the `Machine` object in the case of `test1-workers-bx4wp`.
+An additional detail is that the `Machine` object `test1-workers-bx4wp` is
+controlled by the `test1` `MachineDeployment` the object thus in order to avoid
+reprovisioning of the `Machine` object the `MachineDeployment` has to be
+deleted instead of the `Machine` object in the case of `test1-workers-bx4wp`.
 
 ```console
 $ # By deleting the Machine or MachineDeployment object the related Metal3Machine object(s) should be deleted automatically.
@@ -488,15 +534,20 @@ $ kubectl delete machine test1-m77bn -n metal3
 machine.cluster.x-k8s.io "test1-m77bn" deleted
 
 
-$ # When a Machine object is deleted directly and not by deleting a MachineDeployment the "machine.cluster.x-k8s.io "test1-m77bn" deleted" will be only visible when the Machine and the
-$ # related Metal3Machine object has been fully removed from the cluster. The deletion process could take a few minutes thus the command line will be unresponsive (blocked) for the time being.
+$ # When a Machine object is deleted directly and not by deleting a
+$ # MachineDeployment the "machine.cluster.x-k8s.io "test1-m77bn" deleted" will
+$ # be only visible when the Machine and the related Metal3Machine object has
+$ # been fully removed from the cluster. The deletion process could take a few
+$ # minutes thus the command line will be unresponsive (blocked) for the time
+$ # being.
 
 
 $ kubectl delete cluster test1 -n metal3
 cluster.cluster.x-k8s.io "test1" deleted
 ```
 
-Once the deletion has finished, you can see that the `BareMetalHosts` are offline and `Cluster` object is not present anymore
+Once the deletion has finished, you can see that the `BareMetalHosts` are
+offline and `Cluster` object is not present anymore
 
 ```console
 $ kubectl get baremetalhosts -n metal3
@@ -512,8 +563,10 @@ No resources found in metal3 namespace.
 ### 2.4. Running Custom Baremetal-Operator
 
 The `baremetal-operator` comes up running in the cluster by default, using an
-image built from the [metal3-io/baremetal-operator](https://github.com/metal3-io/baremetal-operator) repository. If you’d like to test changes to the
-`baremetal-operator`, you can follow this process.
+image built from the
+[metal3-io/baremetal-operator](https://github.com/metal3-io/baremetal-operator)
+repository. If you'd like to test changes to the `baremetal-operator`, you can
+follow this process.
 
 First, you must scale down the deployment of the `baremetal-operator` running
 in the cluster.

--- a/docs/user-guide/src/ipam/introduction.md
+++ b/docs/user-guide/src/ipam/introduction.md
@@ -3,15 +3,38 @@
 The IPAM project provides a controller to manage static IP address allocations
 in [Cluster API Provider Metal3](https://github.com/metal3-io/cluster-api-provider-metal3/).
 
-In CAPM3, the Network Data need to be passed to Ironic through the BareMetalHost. CAPI addresses the deployment of Kubernetes clusters and nodes, using the Kubernetes API. As such, it uses objects such as MachineDeployments (similar to deployments for pods) that takes care of creating the requested number of machines, based on templates. The replicas can be increased by the user, triggering the creation of new machines based on the provided templates. Considering the KubeadmControlPlane and MachineDeployment features in Cluster API, it is not possible to provide static IP addresses for each machine before the actual deployments.
+In CAPM3, the Network Data need to be passed to Ironic through the
+BareMetalHost. CAPI addresses the deployment of Kubernetes clusters and nodes,
+using the Kubernetes API. As such, it uses objects such as MachineDeployments
+(similar to deployments for pods) that takes care of creating the requested
+number of machines, based on templates. The replicas can be increased by the
+user, triggering the creation of new machines based on the provided templates.
+Considering the KubeadmControlPlane and MachineDeployment features in Cluster
+API, it is not possible to provide static IP addresses for each machine before
+the actual deployments.
 
-In addition, all the resources from the source cluster must support the CAPI pivoting, i.e. being copied and recreated in the target cluster. This means that all objects must contain all needed information in their spec field to recreate the status in the target cluster without losing information. All objects must, through a tree of owner references, be attached to the cluster object, for the pivoting to proceed properly.
+In addition, all the resources from the source cluster must support the CAPI
+pivoting, i.e. being copied and recreated in the target cluster. This means
+that all objects must contain all needed information in their spec field to
+recreate the status in the target cluster without losing information. All
+objects must, through a tree of owner references, be attached to the cluster
+object, for the pivoting to proceed properly.
 
-Moreover, there are use cases that the users want to specify multiple non-continuous ranges of IP addresses, use the same pool across multiple Template objects, or rule out some IP addresses that might be in use for any reason after the deployment.
+Moreover, there are use cases that the users want to specify multiple
+non-continuous ranges of IP addresses, use the same pool across multiple
+Template objects, or rule out some IP addresses that might be in use for any
+reason after the deployment.
 
-The IPAM is introduced to manage the allocations of IP subnet according to the requests without handling any use of those addresses. The IPAM adds the flexibility by providing the address right before provisioning the node. It can share a pool across MachineDeployment or KubeadmControlPlane, allow non-continuous pools and external IP management by using IPAddress CRs, offer predictable IP addresses, and it is resilient to the *clusterctl move* operation.
+The IPAM is introduced to manage the allocations of IP subnet according to the
+requests without handling any use of those addresses. The IPAM adds the
+flexibility by providing the address right before provisioning the node. It can
+share a pool across MachineDeployment or KubeadmControlPlane, allow
+non-continuous pools and external IP management by using IPAddress CRs, offer
+predictable IP addresses, and it is resilient to the *clusterctl move*
+operation.
 
-In order to use IPAM, both the CAPI and IPAM controllers are required, since the IPAM controller has a dependency on Cluster API *Cluster* objects.
+In order to use IPAM, both the CAPI and IPAM controllers are required, since
+the IPAM controller has a dependency on Cluster API *Cluster* objects.
 
 ## IPAM components
 
@@ -47,7 +70,8 @@ spec:
 
 The *spec* field contains the following fields:
 
-* **clusterName**: Name of the cluster to which this pool belongs, it is used to verify whether the resource is paused.
+* **clusterName**: Name of the cluster to which this pool belongs, it is used
+  to verify whether the resource is paused.
 * **namePrefix**: The prefix used to generate the IPAddress.
 * **pools**: List of IP address pools
 * **prefix**: Default prefix for this IPPool
@@ -58,7 +82,8 @@ The *prefix* and *gateway* can be overridden per pool. Here is the pool definiti
 
 * **start**: IP range start address and it can be omitted if **subnet** is set.
 * **end**: IP range end address and can be omitted.
-* **subnet**: Subnet for the allocation and can be omitted if **start** is set. It is used to verify that the allocated address belongs to this subnet.
+* **subnet**: Subnet for the allocation and can be omitted if **start** is set.
+  It is used to verify that the allocated address belongs to this subnet.
 * **prefix**: Override of the default prefix for this pool
 * **gateway**: Override of the default gateway for this pool
 
@@ -93,7 +118,9 @@ The *annotations* field contains the following optional parameter:
 
 ### IPAddress
 
-An IPAddress is an object representing an IP address allocation. It will be created by IPAM to fill an IPClaim, so that user does not have to create it manually.
+An IPAddress is an object representing an IP address allocation. It will be
+created by IPAM to fill an IPClaim, so that user does not have to create it
+manually.
 
 Example IPAddress:
 

--- a/docs/user-guide/src/ipam/ipam_installation.md
+++ b/docs/user-guide/src/ipam/ipam_installation.md
@@ -4,17 +4,30 @@ This section will show how  IPAM can be installed as a deployment in a cluster.
 
 ## Deploying controllers
 
-CAPI and IPAM controllers need to be deployed at the beginning. The IPAM controller has a dependency on Cluster API *Cluster* objects. CAPI CRDs and controllers must be deployed and the cluster objects should exist for successful deployments.
+CAPI and IPAM controllers need to be deployed at the beginning. The IPAM
+controller has a dependency on Cluster API *Cluster* objects. CAPI CRDs and
+controllers must be deployed and the cluster objects should exist for
+successful deployments.
 
 ## Deployment
 
-The user can create the **IPPool** object independently. It will wait for its cluster to exist before reconciling. If the user wants to create **IPAddress** objects manually, they should be created before any claims. It is highly recommended to use the *preAllocations* field itself or have the reconciliation paused.
+The user can create the **IPPool** object independently. It will wait for its
+cluster to exist before reconciling. If the user wants to create **IPAddress**
+objects manually, they should be created before any claims. It is highly
+recommended to use the *preAllocations* field itself or have the reconciliation
+paused.
 
-After an **IPClaim** object creation, the controller will list all existing **IPAddress** objects. It will then select randomly an address that has not been allocated yet and is not in the *preAllocations* map. It will then create an **IPAddress** object containing the references to the **IPPool** and **IPClaim** and the address, the prefix from the address pool or the default prefix, and the gateway from the address pool or the default gateway.
+After an **IPClaim** object creation, the controller will list all existing
+**IPAddress** objects. It will then select randomly an address that has not
+been allocated yet and is not in the *preAllocations* map. It will then create
+an **IPAddress** object containing the references to the **IPPool** and
+**IPClaim** and the address, the prefix from the address pool or the default
+prefix, and the gateway from the address pool or the default gateway.
 
 ### Deploy IPAM
 
-Deploys IPAM CRDs and IPAM controllers. We can run Makefile target from inside the cloned IPAM git repo.
+Deploys IPAM CRDs and IPAM controllers. We can run Makefile target from inside
+the cloned IPAM git repo.
 
 ```sh
     make deploy
@@ -44,7 +57,10 @@ Runs IPAM controller locally
 
 ## Deletion
 
-When deleting an **IPClaim** object, the controller will simply delete the associated **IPAddress** object. Once all **IPAddress** objects have been deleted, the **IPPool** object can be deleted. Before that point, the finalizer in the **IPPool** object will block the deletion.
+When deleting an **IPClaim** object, the controller will simply delete the
+associated **IPAddress** object. Once all **IPAddress** objects have been
+deleted, the **IPPool** object can be deleted. Before that point, the finalizer
+in the **IPPool** object will block the deletion.
 
 ## References
 

--- a/docs/user-guide/src/ironic/ironic-python-agent.md
+++ b/docs/user-guide/src/ironic/ironic-python-agent.md
@@ -1,25 +1,37 @@
 # Ironic Python Agent (IPA)
 
-[IPA](https://docs.openstack.org/ironic-python-agent/latest/) is a service written in python that runs within a ramdisk. It provides remote access for `Ironic` to perform various operations on the managed server. It also sends information about the server to `Ironic`.
+[IPA](https://docs.openstack.org/ironic-python-agent/latest/) is a service
+written in python that runs within a ramdisk. It provides remote access for
+`Ironic` to perform various operations on the managed server. It also sends
+information about the server to `Ironic`.
 
-By default, we pull IPA images from [Ironic upstream](https://tarballs.opendev.org/openstack/ironic-python-agent/dib/) archive where an image is built on every commit to the *master* git branch.
+By default, we pull IPA images from
+[Ironic upstream](https://tarballs.opendev.org/openstack/ironic-python-agent/dib/)
+archive where an image is built on every commit to the *master* git branch.
 
-However, another remote registry or a local IPA archive can be specified. [ipa-downloader](https://github.com/metal3-io/ironic-ipa-downloader) is responsible for downloading the IPA ramdisk image to a shared volume from where the nodes are able to retrieve it.
+However, another remote registry or a local IPA archive can be specified.
+[ipa-downloader](https://github.com/metal3-io/ironic-ipa-downloader) is
+responsible for downloading the IPA ramdisk image to a shared volume from where
+the nodes are able to retrieve it.
 
 ## Data flow
 
-IPA interacts with other components. The information exchanged and the component to which it is sent to or received from are described below.
-The communication between IPA and these components can be encrypted in-transit with SSL/TLS.
+IPA interacts with other components. The information exchanged and the
+component to which it is sent to or received from are described below.
+The communication between IPA and these components can be encrypted in-transit
+with SSL/TLS.
 
-- Inspection: data about hardware details, such as CPU, disk, RAM and network interfaces.
+- Inspection: data about hardware details, such as CPU, disk, RAM and network
+  interfaces.
 - Heartbeat: periodic message informing Ironic that the node is still running.
-- Lookup: data sent to Ironic that helps it determine Ironic’s node UUID for the node.
+- Lookup: data sent to Ironic that helps it determine Ironic's node UUID for
+  the node.
 
 The above data is sent/received as follows.
 
 - Inspection result is sent to Ironic
-- Lookup/heartbeats data is sent to Ironic.
-- User supplied boot image that will be written to the node’s disk is retrieved from HTTPD server
+- User supplied boot image that will be written to the node's disk is
+  retrieved from HTTPD server
 
 ## References
 

--- a/docs/user-guide/src/ironic/ironic_installation.md
+++ b/docs/user-guide/src/ironic/ironic_installation.md
@@ -47,7 +47,8 @@ folders that will help us to install Ironic for each mentioned case. In each
 of these deployments, a ConfigMap will be created and mounted to the Ironic pod.
 The ConfigMap will be populated based on environment variables from
 [ironic-deployment/default/ironic_bmo_configmap.env](https://github.com/metal3-io/baremetal-operator/blob/main/ironic-deployment/default/ironic_bmo_configmap.env).
-As such, update `ironic_bmo_configmap.env` with your custom values before deploying the Ironic.
+As such, update `ironic_bmo_configmap.env` with your custom values before
+deploying the Ironic.
 
 **WARNING:** Ironic normally listens on the host network of the control plane
 nodes. If you do not enable authentication, anyone with access to this network
@@ -118,9 +119,9 @@ installation script. This will start below containers:
 - httpd
 - mariadb; if `IRONIC_USE_MARIADB` = "true"
 
-If in-cluster ironic installation, we used different manifests for TLS and basic auth,
-here we are exporting environment variables for enabling/disabling TLS & basic auth
-but use the same script.
+If in-cluster ironic installation, we used different manifests for TLS and
+basic auth, here we are exporting environment variables for enabling/disabling
+TLS & basic auth but use the same script.
 
 TLS and Basic authentication disabled (not recommended)
 

--- a/docs/user-guide/src/troubleshooting.md
+++ b/docs/user-guide/src/troubleshooting.md
@@ -92,7 +92,7 @@ Ironic's internal database.
 ## BMH registration errors
 
 BMC credentials may be incorrect or missing. These issues appear in the
-BareMetalHost’s status and in Events.
+BareMetalHost's status and in Events.
 
 Check both `kubectl describe bmh <name>` and recent Events for details.
 

--- a/docs/user-guide/src/version_support.md
+++ b/docs/user-guide/src/version_support.md
@@ -51,8 +51,8 @@ The compatibility of IPAM and CAPM3 API versions with CAPI is discussed
 ## Baremetal Operator
 
 Since `capm3-v1.1.2`, BMO follows the semantic versioning scheme for its own
-release cycle, the same way as CAPM3 and IPAM. Two branches are maintained as supported releases.
-Following table summarizes BMO release/test process:
+release cycle, the same way as CAPM3 and IPAM. Two branches are maintained as
+supported releases. Following table summarizes BMO release/test process:
 
 | Minor release | Status    |
 | ------------- | --------- |

--- a/processes/reviewer-permissions-migration.md
+++ b/processes/reviewer-permissions-migration.md
@@ -61,7 +61,7 @@ process for that.
 
 If we focus on the transition for now, we can define that process
 separately later. So, I propose that we take the contributors with 10
-or more commits according to github’s contribution list (via the page
+or more commits according to github's contribution list (via the page
 like
 <https://github.com/metal3-io/cluster-api-provider-metal3/graphs/contributors>)
 as the initial set of reviewers for each repo. That will allow us to
@@ -69,7 +69,7 @@ complete the migration and we can expand the list further afterwards.
 
 After we agree on this process, I will propose PRs to each repo to add
 reviewers to the owners files. When we have merged those PRs, we can
-change Prow’s configuration to have it use the OWNERS file instead of
+change Prow's configuration to have it use the OWNERS file instead of
 github org membership for /lgtm permissions. We should also update the
 maintainers process document to include instructions for managing the
 list of org members and for managing the reviewer list for a repo.

--- a/security/self-assessment.md
+++ b/security/self-assessment.md
@@ -44,7 +44,7 @@ Metal3 has been in CNCF Sandbox since 2020, and is now applying for
 
 ## Overview
 
-The Metal3 Project (pronounced: “Metal Kubed”) empowers organizations with a
+The Metal3 Project (pronounced: "Metal Kubed") empowers organizations with a
 flexible, open-source solution for bare metal provisioning that combines the
 benefits of bare metal performance with the ease of use and automation provided
 by Kubernetes. Metal3 provides a comprehensive set of components for baremetal
@@ -72,7 +72,7 @@ of bare-metal infrastructure.
 
 This is paired with one of the components from the OpenStack ecosystem, Ironic
 for booting and installing machines. Metal³ handles the installation of Ironic
-as a standalone component (there’s no need to bring along the rest of
+as a standalone component (there's no need to bring along the rest of
 OpenStack). Ironic is supported by a mature community of hardware vendors and
 supports a wide range of bare metal management protocols which are continuously
 tested on a variety of hardware. Backed by Ironic, Metal³ can provision
@@ -114,13 +114,13 @@ hosts, represented in Kubernetes by BareMetalHost (BMH) custom resources.
 
 BMO is responsible for the following operations:
 
-* Inspecting the host’s hardware and reporting the details on the corresponding
+* Inspecting the host's hardware and reporting the details on the corresponding
    BareMetalHost. This includes information about CPUs, RAM, disks, NICs, and
    more.
 * Optionally preparing the host by configuring RAID, changing firmware settings
    or updating the system and/or BMC firmware.
 * Provisioning the host with a desired image.
-* Cleaning the host’s disk contents before and after provisioning.
+* Cleaning the host's disk contents before and after provisioning.
 
 Under the hood, BMO uses Ironic to conduct these actions.
 


### PR DESCRIPTION
Allow lines longer than 80 chars, if they're in tables or code fences. In those, long lines cannot often be avoided, and ignoring them one by one is painful and not pretty.

The same change is applied to all repos with markdownlint, but only on main. Documentation is 99% of the time maintained only in main, so it doesn't matter in release branches.

Fix all markdown files (only repo that was not behaving).
- long lines
- "smart quotes" replaced with regular quotes (unicode for no reason, yuck)