### PR TITLE
Fix redirect link in hardware classification design doc

### DIFF
--- a/design/hardware-classification-controller/support-for-new-parameters-hwcc-DiskAndNIC.md
+++ b/design/hardware-classification-controller/support-for-new-parameters-hwcc-DiskAndNIC.md
@@ -138,7 +138,7 @@ hardware:
 ### Implementation Details/Notes/Constraints
 
 Link for Existing HWCC Specs
-[Existing YAML](https://github.com/metal3-io/hardware-classification-controller/blob/master/config/samples/metal3.io_v1alpha1_hardwareclassification.yaml)
+[Existing YAML](https://github.com/metal3-io/hardware-classification-controller/blob/main/config/samples/metal3.io_v1alpha1_hardwareclassification.yaml)
 
 * Below is sample yaml for additional parameters in HardwareClassification.
 


### PR DESCRIPTION
Updates the link in `support-for-new-parameters-hwcc-DiskAndNIC.md` to point to the `main` branch instead of `master` to resolve the redirect.

Fixes #608