### PR TITLE
Quick-start: Calculate image checksums

### DIFF
--- a/docs/user-guide/examples/capm3-vars.sh
+++ b/docs/user-guide/examples/capm3-vars.sh
@@ -1,10 +1,10 @@
 # Baremetal lab image variables
 # export IMAGE_URL="http://192.168.0.150/CENTOS_10_NODE_IMAGE_K8S_v1.34.1.qcow2"
-# export IMAGE_CHECKSUM="afa7e95ee6fb92b952ab85bae4d01033651e690cf04a626c668041d7b94ddd4a"
+# export IMAGE_CHECKSUM="http://192.168.0.150/CENTOS_10_NODE_IMAGE_K8S_v1.34.1.qcow2.sha256sum"
 # export IMAGE_FORMAT="qcow2"
 # Virtualized setup variables
 export IMAGE_URL="http://192.168.222.1/CENTOS_10_NODE_IMAGE_K8S_v1.34.1.raw"
-export IMAGE_CHECKSUM="20537529c0588e1c3d1929981207ef6fac73df7b2500b84f462d09badcc670ea"
+export IMAGE_CHECKSUM="http://192.168.222.1/CENTOS_10_NODE_IMAGE_K8S_v1.34.1.raw.sha256sum"
 export IMAGE_FORMAT="raw"
 # Common variables
 export IMAGE_CHECKSUM_TYPE="sha256"

--- a/docs/user-guide/examples/image-server.sh
+++ b/docs/user-guide/examples/image-server.sh
@@ -7,11 +7,14 @@ wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.i
 wget https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS
 sha256sum --ignore-missing -c SHA256SUMS
 wget https://artifactory.nordix.org/artifactory/metal3/images/k8s_v1.34.1/CENTOS_10_NODE_IMAGE_K8S_v1.34.1.qcow2
-sha256sum CENTOS_10_NODE_IMAGE_K8S_v1.34.1.qcow2
+# Generate checksum file for the qcow2 image
+sha256sum CENTOS_10_NODE_IMAGE_K8S_v1.34.1.qcow2 > CENTOS_10_NODE_IMAGE_K8S_v1.34.1.qcow2.sha256sum
 # Convert to raw.
 # This helps lower memory requirements, since the raw image can be streamed to disk
 # instead of first loaded to memory by IPA for conversion.
 qemu-img convert -f qcow2 -O raw CENTOS_10_NODE_IMAGE_K8S_v1.34.1.qcow2 CENTOS_10_NODE_IMAGE_K8S_v1.34.1.raw
+# Generate checksum file for the raw image
+sha256sum CENTOS_10_NODE_IMAGE_K8S_v1.34.1.raw > CENTOS_10_NODE_IMAGE_K8S_v1.34.1.raw.sha256sum
 # Local cache of IPA
 wget https://tarballs.opendev.org/openstack/ironic-python-agent/dib/ipa-centos9-master.tar.gz
 popd || exit


### PR DESCRIPTION
The disk images are periodically rebuilt, so the static checksum we had in the docs would become invalid. This commit changes the quick-start guide to calculate the checksum instead.

Fixes #643