### PR TITLE
enforce ol-prefix 'one' style for ordered lists

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,6 +4,8 @@ config:
   ul-indent:
     # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
     indent: 3
+  ol-prefix:
+    style: "one"
   line-length:
     tables: false
     code_blocks: false

--- a/design/api-design-principles.md
+++ b/design/api-design-principles.md
@@ -53,7 +53,7 @@ every API parameter.
    ours. This exposes the underlying API in a way that makes it more
    difficult to change the metal3 API, while simultaneously making
    using metal3 for our users.
-2. Future versions of kubernetes will improve support for OpenAPI
+1. Future versions of kubernetes will improve support for OpenAPI
    validation, and will require good validation by default as a
    security measure. Passing unstructured data through the API and
    storing it exposes clusters to security issues if an API changes

--- a/design/baremetal-operator/bios-config.md
+++ b/design/baremetal-operator/bios-config.md
@@ -27,7 +27,7 @@ attributes in the BareMetalHost YAML.
 
 1. To agree on the format of the attributes that are to be supported
    as a starting point
-2. To keep the attribute naming vendor agnostic
+1. To keep the attribute naming vendor agnostic
 
 ### Non-Goals
 

--- a/design/baremetal-operator/bmc-address.md
+++ b/design/baremetal-operator/bmc-address.md
@@ -30,7 +30,7 @@ potentially the path.
 ### Non-Goals
 
 1. To list the scheme to use for every type of controller.
-2. To specify the user interface for entering address information.
+1. To specify the user interface for entering address information.
 
 ## Proposal
 

--- a/design/baremetal-operator/bmo-part-of-capm3.md
+++ b/design/baremetal-operator/bmo-part-of-capm3.md
@@ -12,11 +12,11 @@ the BaremetalHost during the pivoting.
 
 1. Production.
 
-2. Local developer.
+1. Local developer.
 
-3. Ironic running outside of the cluster.
+1. Ironic running outside of the cluster.
 
-4. Pivoting.
+1. Pivoting.
 
 As a starting point, we decided to have a cleaner structure of the
 `baremetal-operator/deploy` folder and make it as simple as possible and it will

--- a/design/baremetal-operator/deploy-steps.md
+++ b/design/baremetal-operator/deploy-steps.md
@@ -82,16 +82,16 @@ The expected workflow is as follows:
 
 1. A user sets `CustomDeploy.Method = "step_name"` and optionally `Image.URL`,
    `UserData` and `NetworkData`.
-2. BMO sets `Node.DeployInterface = "custom-agent"` and requests deployment
+1. BMO sets `Node.DeployInterface = "custom-agent"` and requests deployment
    with a custom deploy step `step_name`.
-3. Ironic boots the agent (if not booted for inspection/cleaning already).
-4. Ironic requests the agent to execute the deploy step `step_name` (it is
+1. Ironic boots the agent (if not booted for inspection/cleaning already).
+1. Ironic requests the agent to execute the deploy step `step_name` (it is
    an error to provide a non-existing step), providing it the complete Node
    object, including `configdrive`.
-5. Ironic waits for the step to finish.
-6. Ironic configures the Node's boot device and clean ups the deployment
+1. Ironic waits for the step to finish.
+1. Ironic configures the Node's boot device and clean ups the deployment
    environment.
-7. Ironic reboots the node into the instance.
+1. Ironic reboots the node into the instance.
 
 On failure (including unsupported deploy step) the node will be moved to the
 `deploy failed` state, and the `LastError` field will be populated.

--- a/design/baremetal-operator/hardware-status.md
+++ b/design/baremetal-operator/hardware-status.md
@@ -38,8 +38,8 @@ up-to-date vision on the status of the devices.
 ### Goals
 
 1. Decide which information on the devices to retrieve.
-2. Agree on how to retrieve such information.
-3. Provide a way to manually/automatically collect and update the
+1. Agree on how to retrieve such information.
+1. Provide a way to manually/automatically collect and update the
    devices information.
 
 ### Non-Goals

--- a/design/baremetal-operator/hardwaredata_crd.md
+++ b/design/baremetal-operator/hardwaredata_crd.md
@@ -116,7 +116,7 @@ the current state of the BareMetalHost.
     finalizer blocks HardwareData deletion until BareMetalHost exists.
 - host is available:
     1. copy inspection data from the status of BareMetalHost if exists;
-    2. re-inspect the host if inspection data doesn't exist in the BareMetalHost
+    1. re-inspect the host if inspection data doesn't exist in the BareMetalHost
         status. This will be the first and only option in the future when
         `status.hardware` is removed;
 

--- a/design/baremetal-operator/host-live-updates.md
+++ b/design/baremetal-operator/host-live-updates.md
@@ -96,13 +96,13 @@ As an operator, I want to update firmware on my Kubernetes worker node. My
 actions:
 
 1. Mark the affected node as non-schedulable, drain the workloads from it.
-2. Find the corresponding `HostFirmwareComponents` resource, edit it to put
+1. Find the corresponding `HostFirmwareComponents` resource, edit it to put
    an HTTP link to the expected firmware image(s).
-3. Edit the `BareMetalHost` resource to add the reboot annotations.
-4. Wait for the host's `operationalStatus` field to first change to
+1. Edit the `BareMetalHost` resource to add the reboot annotations.
+1. Wait for the host's `operationalStatus` field to first change to
    `servicing`, then back to `OK`.
-5. Wait for the node's status to become `Ready` again.
-6. Mark the node as schedulable.
+1. Wait for the node's status to become `Ready` again.
+1. Mark the node as schedulable.
 
 ### Implementation Details/Notes/Constraints
 

--- a/design/baremetal-operator/how-ironic-works.md
+++ b/design/baremetal-operator/how-ironic-works.md
@@ -64,22 +64,22 @@ whole disk images.
 The basic workflow consists of:
 
 1. Booting the deployment ramdisk
-2. The deployment ramdisk checks in with the ironic introspection
+1. The deployment ramdisk checks in with the ironic introspection
    service which updates configuration information stored in ironic
    about the baremetal machine.
-3. The deployment ramdisk checks in with the ironic service and leverages
+1. The deployment ramdisk checks in with the ironic service and leverages
    the MAC addresses to help identify the physical machine in the hardware
    inventory.
-4. Ironic initiates deployment by first identifying the root disk upon
+1. Ironic initiates deployment by first identifying the root disk upon
    which the disk image is to be written. By default this will be the
    smallest storage device available, and can be overridden via explicit
    configuration of a [root_device hint](https://docs.openstack.org/ironic/latest/install/advanced.html#specifying-the-disk-for-deployment-root-device-hints)
-5. The deployment ramdisk downloads the image to be written and streams
+1. The deployment ramdisk downloads the image to be written and streams
    that to the storage device.
-6. If defined as part of the deployment, ironic will add an additional
+1. If defined as part of the deployment, ironic will add an additional
    partition for a configuration drive. Ironic will then write the
    configuration drive to disk
-7. Finally ironic reboots the machine.
+1. Finally ironic reboots the machine.
 
 There are some additional steps that ironic performs, mainly fixing
 partition table data with GPT based partition tables in order to
@@ -320,7 +320,7 @@ Starting with the bare metal node in the "available" provision_state:
    an API client. The instance_uuid can be set to any value, and is
    ultimately not required.
 
-2. Request ironic to perform a "validate" operation on the information
+1. Request ironic to perform a "validate" operation on the information
    it is presently configured with. The expected response is a HTTP 200
    return code, with a message body that consists of a list of "driver"
    interfaces and any errors if applicable.
@@ -344,28 +344,28 @@ Starting with the bare metal node in the "available" provision_state:
 
    More information can be found in the [API documentation](https://docs.openstack.org/api-ref/baremetal/?expanded=validate-node-detail).
 
-3. Craft a configuration drive file
+1. Craft a configuration drive file
 
    Configuration drives are files that contain a small ISO9660 filesystem
    which contains configuration metadata and user defined "user-data".
 
-   1) Create a folder called "TEMPDIR"
-   2) In the case of ignition based configuration, that file would be
+   1. Create a folder called "TEMPDIR"
+   1. In the case of ignition based configuration, that file would be
       renamed "user_data" and placed in `TEMPDIR/openstack/latest/`
       folder.
-   3) Metadata for networking configuration setup using "cloud-init" or
+   1. Metadata for networking configuration setup using "cloud-init" or
       a similar application would also be written to the
       `TEMPDIR/openstack/latest` as well. This is out of scope, but is well
       documented in the OpenStack community.
-   4) Create an iso9660 image containing the contents of TEMPDIR using
+   1. Create an iso9660 image containing the contents of TEMPDIR using
       a label of "config-2".
-   5) Compress the resulting ISO9660 image file using the gzip
+   1. Compress the resulting ISO9660 image file using the gzip
       algorithm.
-   6) Encode the resulting gzip compressed image file in base64 for
+   1. Encode the resulting gzip compressed image file in base64 for
       storage and transport. Ironic does the needful to decode and decompress
       the configuration drive prior to deployment.
 
-4. Send a HTTP POST to `/v1/nodes/node-id/states/provision` to initiate
+1. Send a HTTP POST to `/v1/nodes/node-id/states/provision` to initiate
    the deployment
 
    ```json
@@ -378,7 +378,7 @@ Starting with the bare metal node in the "available" provision_state:
    steps to help ensure the baremetal node reboots into the requested
    disk image.
 
-5. Monitor the provisioning operation by [fetching the machine
+1. Monitor the provisioning operation by [fetching the machine
    state](#how-do-i-identify-the-current-state) periodically, looking
    for it to be set to `active`.
 

--- a/design/baremetal-operator/inspector-deprecation.md
+++ b/design/baremetal-operator/inspector-deprecation.md
@@ -152,10 +152,10 @@ The rough upgrade plan will be:
 
 1. Upgrade BMO to the version that supports both ironic-inspector and the new
    inspection.
-2. Update ironic-image to the version that allows disabling ironic-inspector.
-3. Change the Ironic deployment to enable the new inspection and disable
+1. Update ironic-image to the version that allows disabling ironic-inspector.
+1. Change the Ironic deployment to enable the new inspection and disable
    ironic-inspector.
-4. Further upgrades are possible at this point.
+1. Further upgrades are possible at this point.
 
 Operators not using ironic-image will need to decide on their strategy.
 They will be able to use new BMO for the time being, but will be encouraged

--- a/design/baremetal-operator/kubebuilder-migration.md
+++ b/design/baremetal-operator/kubebuilder-migration.md
@@ -109,17 +109,17 @@ admission web hooks to validate BareMetalHost resources.
 The process for creating the proof-of-concept migration was basically:
 
 1. Move everything in the git repository out of the way.
-2. Remove the copy of operator-sdk.
-3. Use kubebuilder init to create a new project in the repository,
+1. Remove the copy of operator-sdk.
+1. Use kubebuilder init to create a new project in the repository,
    setting the domain to an empty string.
-4. Update the kubebuilder and controller-gen settings to allow "unsafe
+1. Update the kubebuilder and controller-gen settings to allow "unsafe
    fields".
-5. Use kubebuilder to create an API and controller for BareMetalHost,
+1. Use kubebuilder to create an API and controller for BareMetalHost,
    then replace the implementations with the existing ones.
-6. Restore the rest of the existing code from the pkg directory,
+1. Restore the rest of the existing code from the pkg directory,
    moving it to the root of the repository.
-7. Fix everything so it compiles and the tests run.
-8. Add missing targets to the Makefile (lint, sec, openapi generation,
+1. Fix everything so it compiles and the tests run.
+1. Add missing targets to the Makefile (lint, sec, openapi generation,
    etc.).
 
 ### Implementation Details/Notes/Constraints
@@ -169,12 +169,12 @@ make future API changes easier to follow.
 
 1. Tag a release and create a maintenance branch for the
    baremetal-operator.
-2. Follow a process as described in the Design Details section above
+1. Follow a process as described in the Design Details section above
    to migrate to kubebuilder.
-3. Tag a release to use for including in the cluster API providers.
-4. Rebase all open PRs after the new implementation is approved.
-5. Update the imports in CAPM3.
-6. Update the imports and vendoring in CAPBM (only for downstream
+1. Tag a release to use for including in the cluster API providers.
+1. Rebase all open PRs after the new implementation is approved.
+1. Update the imports in CAPM3.
+1. Update the imports and vendoring in CAPBM (only for downstream
    consumers).
 
 ### Dependencies

--- a/design/baremetal-operator/limit-hosts-provisioning.md
+++ b/design/baremetal-operator/limit-hosts-provisioning.md
@@ -33,8 +33,8 @@ could suffer issues produced from the sudden resources depletion
 ### Non-Goals
 
 1. Optimize the deployment time of large batches of nodes
-2. Allow the user to configure such behavior
-3. Modify the current Ironic service layout
+1. Allow the user to configure such behavior
+1. Modify the current Ironic service layout
 
 ## Proposal
 

--- a/design/baremetal-operator/managing-provisioning-dependencies.md
+++ b/design/baremetal-operator/managing-provisioning-dependencies.md
@@ -33,7 +33,7 @@ how to support ironic/dnsmasq integration, how to load images for use.
 ### Non-Goals
 
 1. To list the scheme to use for every type of controller.
-2. To specify the user interface for entering address information.
+1. To specify the user interface for entering address information.
 
 ## Proposal
 
@@ -43,9 +43,9 @@ The ironic+bmo pod has a number of constraints that cause a fairly
 specific configuration to be required.  These include:
 
 1. Having the images available for download via http and tftp
-2. Having a static IP on the provisioning network so that dnsmasq
+1. Having a static IP on the provisioning network so that dnsmasq
    can operate as a DHCP server to serve PXE requests.
-3. Shared storage for ironic, ironic inspector, and dnsmasq to allow
+1. Shared storage for ironic, ironic inspector, and dnsmasq to allow
    ironic to update the image being deployed via dnsmasq configuration
    changes.
 
@@ -66,13 +66,13 @@ From the ip-address manpage:
 - valid_lft LFT
 
   The valid lifetime of this address; see section 5.5.4 of RFC
-  4862. When it expires, the address is removed by the kernel.
+  1. When it expires, the address is removed by the kernel.
   Defaults to forever.
 
 - preferred_lft LFT
 
   The preferred lifetime of this address; see section 5.5.4 of RFC
-  4862. When it expires, the address is no longer used for new outgoing
+  1. When it expires, the address is no longer used for new outgoing
   connections. Defaults to forever.
 
 So again, an init container is used to set the IP address to a
@@ -101,7 +101,7 @@ we could use here to perform fencing in this situation.
 
 1. Use access to the shared storage as a method to determine if we
    have lost connectivity and self-fence.
-2. Have the new ironic pod destroy the previous node if it can safely
+1. Have the new ironic pod destroy the previous node if it can safely
    determine that the old host is still running.
 
 ## Design Details

--- a/design/baremetal-operator/raid-api.md
+++ b/design/baremetal-operator/raid-api.md
@@ -22,21 +22,21 @@ metal3 could do that work for them.
 
 1. Provide an API to specify the RAID storage configuration to use
    when provisioning a host.
-2. Outline the controller/provisioner logic changes needed to pass the
+1. Outline the controller/provisioner logic changes needed to pass the
    instructions to Ironic to have the storage configured.
-3. Support basic RAID levels `0`, `1`, and `1+0`.
+1. Support basic RAID levels `0`, `1`, and `1+0`.
 
 ### Non-Goals
 
 1. Provide default RAID configuration.
-2. Retain existing RAID configuration on a host if it matches the
+1. Retain existing RAID configuration on a host if it matches the
    desired configuration at the time of provisioning (we make no
    assumptions about preserving the state of the storage system or its
    contents).
-3. Re-provision a host if the RAID settings change. (Users are
+1. Re-provision a host if the RAID settings change. (Users are
    expected to explicitly deprovision the host and then reprovision
    it.)
-4. Support every possible RAID configuration.
+1. Support every possible RAID configuration.
 
 ## Proposal
 
@@ -44,7 +44,7 @@ metal3 could do that work for them.
 
 1. As a user, I can specify the RAID configuration for a host before
    provisioning it.
-2. As a user, I can choose between hardware and software RAID for each
+1. As a user, I can choose between hardware and software RAID for each
    host.
 
 ## Design Details

--- a/design/baremetal-operator/unmanaged-state.md
+++ b/design/baremetal-operator/unmanaged-state.md
@@ -97,8 +97,8 @@ section.
 
 1. Define the new state:
    <https://github.com/metal3-io/baremetal-operator/pull/571>
-2. Update `cluster-api-provider-metal3` delete code
-3. Update `baremetal-operator` to implement the new state:
+1. Update `cluster-api-provider-metal3` delete code
+1. Update `baremetal-operator` to implement the new state:
    <https://github.com/metal3-io/baremetal-operator/pull/569/>
 
 ### Upgrade / Downgrade Strategy

--- a/design/baremetal-operator/user-defined-root-device-hints.md
+++ b/design/baremetal-operator/user-defined-root-device-hints.md
@@ -34,7 +34,7 @@ available so that device is not chosen randomly
 ### Goals
 
 1. Decide which root device hints are needed be supported.
-2. Agree on the way how information is propagated to ironic through BMO
+1. Agree on the way how information is propagated to ironic through BMO
 
 ### Non-Goals
 

--- a/design/cluster-api-provider-metal3/allow_disabling_node_disk_cleaning.md
+++ b/design/cluster-api-provider-metal3/allow_disabling_node_disk_cleaning.md
@@ -138,22 +138,22 @@ spec:
 1. User wants to disable disk cleaning before upgrading the nodes that are part
    of the same KCP/MD.
 
-2. User sets Disabled for the `automatedCleaningMode` field on a
+1. User sets Disabled for the `automatedCleaningMode` field on a
    Metal3MachineTemplate which is referenced by `infrastructureTemplate` field
    in the KCP/MD.
 
-3. Metal3MachineTemplate controller keeps reconciling the Metal3MachineTemplate objects.
+1. Metal3MachineTemplate controller keeps reconciling the Metal3MachineTemplate objects.
    Once the update is seen on the Metal3MachineTemplate, Metal3MachineTemplate controller
    starts mapping all the Metal3Machines referenced by that particular Metal3MachineTemplate,
    and updates the `automatedCleaningMode` field to Disabled on all the referenced
    Metal3Machines.
 
-4. Metal3Machine controller keeps reconciling the Metal3Machine objects.
+1. Metal3Machine controller keeps reconciling the Metal3Machine objects.
    Once the update is seen on the Metal3Machine, Metal3Machine controller starts
    mapping the BareMetalHosts referenced by the Metal3Machines, and updates the
    `automatedCleaningMode` field to Disabled on all the referenced BaremetalHosts.
 
-5. Since the `automatedCleaningMode` field is set to Disabled on the BaremetalHosts,
+1. Since the `automatedCleaningMode` field is set to Disabled on the BaremetalHosts,
    Baremetal Operator instructs the Ironic to disable disk cleaning for Ironic
    nodes referenced by the BaremetalHosts.
 
@@ -161,10 +161,10 @@ spec:
 
 1. User wants to disable disk cleaning for a single host
 
-2. User sets Disabled for the `automatedCleaningMode` field on a
+1. User sets Disabled for the `automatedCleaningMode` field on a
    BareMetalHost spec.
 
-3. Baremetal Operator keeps reconciling the BareMetalHost, and after the update on
+1. Baremetal Operator keeps reconciling the BareMetalHost, and after the update on
    the BareMetalHost, BMO instructs the Ironic to disable disk cleaning
    for the node.
 
@@ -224,7 +224,7 @@ cleaning. However, this option introduces a couple of issues:
 1. As mentioned by @dtantsur in [2008113](https://storyboard.openstack.org/#!/story/2008113)
    there could be some security concerns if we disable automated cleaning globally.
 
-2. Upgrade operations do not happen as frequently as provisioning & de-provisioning.
+1. Upgrade operations do not happen as frequently as provisioning & de-provisioning.
    As such, this would require admins to always enable node automated
    cleaning whenever they perform normal provisioning/de-provisioning.
 

--- a/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md
+++ b/design/cluster-api-provider-metal3/capm3-remediation-controller-proposal.md
@@ -249,6 +249,6 @@ no version skew.
 ## References
 
 1. [CAPI MachineHealthCheck](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking)
-2. [CAPI External Remediation Proposal](https://github.com/kubernetes-sigs/cluster-api/pull/3190/files)
-3. [re-inspection API proposal](https://github.com/metal3-io/metal3-docs/blob/main/design/baremetal-operator/inspection-api.md)
-4. [BareMetalHost v1alpha2 API Migration](https://github.com/metal3-io/metal3-docs/pull/101)
+1. [CAPI External Remediation Proposal](https://github.com/kubernetes-sigs/cluster-api/pull/3190/files)
+1. [re-inspection API proposal](https://github.com/metal3-io/metal3-docs/blob/main/design/baremetal-operator/inspection-api.md)
+1. [BareMetalHost v1alpha2 API Migration](https://github.com/metal3-io/metal3-docs/pull/101)

--- a/design/cluster-api-provider-metal3/node_reuse.md
+++ b/design/cluster-api-provider-metal3/node_reuse.md
@@ -58,7 +58,7 @@ To achieve this, we need to
   This [feature](https://github.com/metal3-io/metal3-docs/blob/main/design/cluster-api-provider-metal3/allow_disabling_node_disk_cleaning.md)
   is implemented.
 
-2. be able reuse the same pool of hosts so that we get the storage
+1. be able reuse the same pool of hosts so that we get the storage
   data back. Currently, there is no mechanism available in Metal³ to pick the
   same pool of hosts that were released while upgrading/remediation - for the
   next provisioning phase. And this proposal tries to solve it.
@@ -131,7 +131,7 @@ We should perform two steps to re-use the same pool of hosts.
 
 1. During host deprovisioning, set the `infrastructure.cluster.x-k8s.io/node-reuse`
   label;
-2. During next provisioning, try to select any host in `Available` state and having
+1. During next provisioning, try to select any host in `Available` state and having
   a matching `infrastructure.cluster.x-k8s.io/node-reuse` label;
 
 The actual implementation will be done within the CAPM3 Machine controller.

--- a/design/community/book-proposal.md
+++ b/design/community/book-proposal.md
@@ -30,15 +30,15 @@ perspective.
 1. Use mdbook tool to create the online/web-based user-guide from
     the markdown-based documents available under /doc in metal3-docs Github repository.
 
-2. Configure Netlify for the book preview as part of a PR review for document changes.
+1. Configure Netlify for the book preview as part of a PR review for document changes.
 
-3. Write-down and add missing documents.
+1. Write-down and add missing documents.
 
 ### Non-Goals
 
 1. Create developer-guide
 
-2. Keep HTML/CSS files within the repository
+1. Keep HTML/CSS files within the repository
 
 ## Proposal
 
@@ -56,13 +56,13 @@ will combine documents under metal3-docs/docs and publish them as a single user-
 
 1. Renders a book content from markdown files
 
-2. Automatically generates all the HTML/CSS files for you
+1. Automatically generates all the HTML/CSS files for you
 
-3. Used by several open source projects including Kubernetes ecosystems such as
+1. Used by several open source projects including Kubernetes ecosystems such as
     Cluster API, Cluster-api-provider-aws, some docs of Kubernetes
     and etc.
 
-4. Offers preview capabilities to detect issues before they get merged.
+1. Offers preview capabilities to detect issues before they get merged.
 
 Netlify deployment will be configured for the metal3-docs repository to have a
 preview process when a future commit introduces documentation changes.
@@ -77,7 +77,7 @@ There are two possible ways for that.
     first run the Makefile target/script under Metal3-docs and then publish the output
     (i.e. final user-guide with updated content).
 
-2. Add the script within Netlify to build the user-guide from the current content
+1. Add the script within Netlify to build the user-guide from the current content
     and configure Netlify automatic-triggering.
 
 **Where do we store mdbook auto-generated files like CSS/HTML ?**
@@ -132,12 +132,12 @@ None
 ### Work Items
 
 1. Write down documentation
-2. Create code-based architectures so that it is easy to modify after a while if
+1. Create code-based architectures so that it is easy to modify after a while if
     there are architectural changes. Example via PlantUml
-3. Configure the Netlify
-4. Refactor the existing documents. This includes typos, indentation, etc.
-5. Write down documentation
-6. Create mdbook book structure
+1. Configure the Netlify
+1. Refactor the existing documents. This includes typos, indentation, etc.
+1. Write down documentation
+1. Create mdbook book structure
 
 ### Dependencies
 
@@ -166,8 +166,8 @@ Use asciidoctor.
 *Advantages:*
 
 1. Asciidoc provides easily referencing documents via the URL.
-2. Can convert the book into different formats, such as HTML, PDF, etc.
-3. Makes it easy to create a book with different versions of the product. For example,
+1. Can convert the book into different formats, such as HTML, PDF, etc.
+1. Makes it easy to create a book with different versions of the product. For example,
     different versions of BMO can introduce new types, etc.
 
 *Disadvantages:*
@@ -178,10 +178,10 @@ Use asciidoctor.
 
 1. Mdbook: <https://github.com/rust-lang/mdBook>
 
-2. Cluster-api book: <https://cluster-api.sigs.k8s.io/>
+1. Cluster-api book: <https://cluster-api.sigs.k8s.io/>
 
-3. Cluster-api-provider-aws book: <https://cluster-api-aws.sigs.k8s.io/>
+1. Cluster-api-provider-aws book: <https://cluster-api-aws.sigs.k8s.io/>
 
-4. PlantUML: <https://plantuml.com/>
+1. PlantUML: <https://plantuml.com/>
 
-5. Asciidoctor: <https://asciidoctor.org/>
+1. Asciidoctor: <https://asciidoctor.org/>

--- a/design/hardware-classification-controller/expected-hardware-configuration-validation.md
+++ b/design/hardware-classification-controller/expected-hardware-configuration-validation.md
@@ -110,23 +110,23 @@ Classification Controller.
 ### Work Items
 
 1. Implement CRD for `HardwareClassification`.
-2. Create the Schema struct for HardwareConfiguration inside
+1. Create the Schema struct for HardwareConfiguration inside
    HardwareClassificationSpec, in file pkg/api/metal3/v1alpha1
    hardwareClassification_types.go
-3. Add a watch on kind BareMetalHost to get updated baremetal host
+1. Add a watch on kind BareMetalHost to get updated baremetal host
    lists.
-4. Fetch baremetal host list from the baremetal operator running in
+1. Fetch baremetal host list from the baremetal operator running in
    the metal3 cluster.
-5. Extract the expectedHardwareConfiguration from HCC profile CR
+1. Extract the expectedHardwareConfiguration from HCC profile CR
    applied to the CRD.
-6. Create a FactoryClassificationManager.go file. Write a function to
+1. Create a FactoryClassificationManager.go file. Write a function to
    call appropriate filter algorithm written in
    ClassificationFilters.go.
-7. Create a ClassificationFilters.go file. Write comparison
+1. Create a ClassificationFilters.go file. Write comparison
    algorithms based on minimum or maximum requirements given by user
    to classify host.
-8. Set labels for baremetal host CR.
-9. Write unit tests for above implementation.
+1. Set labels for baremetal host CR.
+1. Write unit tests for above implementation.
 
 ### Dependencies
 

--- a/design/helm-charts/single-pod-helm-chart.md
+++ b/design/helm-charts/single-pod-helm-chart.md
@@ -77,8 +77,8 @@ through the charts metadata (values.yaml files).
    - `mariadb`
    - `baremetal-operator`
 
-2. Create a CI for building the Helm chart and smoke verification.
-3. Create a CI for testing Helm chart deployment and functional
+1. Create a CI for building the Helm chart and smoke verification.
+1. Create a CI for testing Helm chart deployment and functional
    testing.
 
 ### Dependencies

--- a/design/ironic-debuggability-improvement.md
+++ b/design/ironic-debuggability-improvement.md
@@ -25,7 +25,7 @@ We need to make Ironic logs accessible to the end user.
 ### Goals
 
 1. Make it easier to understand what happened when a deployment fails.
-2. Avoid old logs pile up and take all available space.
+1. Avoid old logs pile up and take all available space.
 
 ### Non-Goals
 
@@ -78,7 +78,7 @@ Both scripts will be added as new container entry points to
 Proposed implementation includes two stages:
 
 1. Print log contents with UUID reference.
-2. Print log contents with node name reference.
+1. Print log contents with node name reference.
 
 The second stage is dependent on these Ironic changes:
 <https://storyboard.openstack.org/#!/story/2008280>

--- a/design/ironic-standalone-operator.md
+++ b/design/ironic-standalone-operator.md
@@ -148,7 +148,7 @@ copies in most cases). This has two benefits:
 
 1. Ironic can be updated in a rolling fashion without an interruption in the
    service.
-2. Due to the way Ironic is designed, each replica will handle its proportion
+1. Due to the way Ironic is designed, each replica will handle its proportion
    (1/3 in most cases) of nodes (active/active architecture, not
    active/backup).
 

--- a/design/sync-labels-bmh-to-node.md
+++ b/design/sync-labels-bmh-to-node.md
@@ -41,7 +41,7 @@ More specifically, synchronization accomplishes the following:
 1. Addition/Removal of a label, within the set of predefined prefixes, on the
   BMH will result in the addition/removal of that label on the corresponding
   Node. Labels outside the prefix set will be ignored.
-2. Addition/Removal of a label, within the set of predefined prefixes,
+1. Addition/Removal of a label, within the set of predefined prefixes,
   *directly* on the Node will result in the removal/re-adding of that label
   on the Node.
 
@@ -98,12 +98,12 @@ Scenario (i) can be handled as follows:
 
     baremetalhosts,verbs=get;list;watch
 
-2. On each BMH reconcile event, the controller will fetch the corresponding
+1. On each BMH reconcile event, the controller will fetch the corresponding
   Node. The *mapping* can be accomplished by:
 
     BMH.ConsumerRef --> Metal3Machine.OwnerRef --> Machine.Status.NodeRef
 
-3. Synchronize the labels and update the Node in the workload cluster. CAPM3
+1. Synchronize the labels and update the Node in the workload cluster. CAPM3
   already fetches the Node objects from the workload clusters today using a
   remote client. We would leverage that same capability here.
 
@@ -190,7 +190,7 @@ Removal of a prefix, p1, from the configuration, has two consequences:
 1. Any additional labels with prefix p1 placed on the BMH will not be
   synchronized to the corresponding Node.
 
-2. Any existing labels with prefix p1 present on the BMH or Node objects
+1. Any existing labels with prefix p1 present on the BMH or Node objects
   will not be removed. Removal of these labels is the users responsibility.
 
 #### Delay between Node create and label sync
@@ -262,15 +262,15 @@ however document this limitation.
     1. Labels are only applicable at creation time. Adding/Removing a new
       label requires a complete MachineDeployment rollout. This is highly
       undesirable in a baremetal environment.
-    2. MachineDeployment grouping may not always provide the needed
+    1. MachineDeployment grouping may not always provide the needed
       granularity; effectively a MachineDeployment == workload type. Depending
       on the how granular the user wants their labeling, this may lead to a
       large number of MachineDeployments.
-    3. There are cases where a logical grouping like MachineDeployment is not
+    1. There are cases where a logical grouping like MachineDeployment is not
       appropriate when trying to capture physical grouping. For example, you
       may want a specific label on all hosts in the same rack but logically
       hosts in the rack may belong to different MachineDeployments.
-    4. There are security concerns with kubelet's `--node-labels` flag (as
+    1. There are security concerns with kubelet's `--node-labels` flag (as
       mentioned in this proposal). This is not a deal breaker but definitely
       undesirable.
 * Using node-feature-discovery to apply labels. This approach is also
@@ -279,7 +279,7 @@ however document this limitation.
       For example, user intent cases such as I want to label certain hosts as
       temporary so only workloads that can tolerate interruptions are scheduled
       there.
-    2. It would require that users deploy (and potentially implement)
+    1. It would require that users deploy (and potentially implement)
       controllers for feature discovery. The proposed mechanism for label sync
       would provide a convenient, albeit more manual, alternative.
 

--- a/design/use-ironic.md
+++ b/design/use-ironic.md
@@ -29,14 +29,14 @@ Kubernetes environment. Ironic meets all of those criteria.
 
 1. Choose an existing provisioning/deployment tool to be used to
    configure hosts and their images.
-2. Create an architecture that allows us to choose a different tool
+1. Create an architecture that allows us to choose a different tool
    later, if we have some reason to do that.
 
 ### Non-Goals
 
 1. Build a new provisioning/deployment tool for the sake of having one
    written in golang.
-2. Integrate with every provisioning/deployment tool potential users
+1. Integrate with every provisioning/deployment tool potential users
    of Metal3 might have in their data centers.
 
 ## Proposal

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -4,9 +4,9 @@ To deploy metal3-components on vanilla K8s cluster, the following prerequisites
 have to be met:
 
 1. **Ironic should have access to layer-2 network for provisioning.**
-2. **Firewall is configured properly**
-3. **Webserver container containing  node images is running and reachable**
-4. **Ironic-bmo-configmap is populated correctly**
+1. **Firewall is configured properly**
+1. **Webserver container containing  node images is running and reachable**
+1. **Ironic-bmo-configmap is populated correctly**
 
 We elaborate these points in detail here:
 
@@ -18,7 +18,7 @@ We elaborate these points in detail here:
    so that it can determine from which host the introspection data is
    coming from.
 
-2. Firewall should be configured to allow the required traffic to pass
+1. Firewall should be configured to allow the required traffic to pass
    through.  The following traffic should be allowed at least:
    - ARP
    - DHCP
@@ -33,7 +33,7 @@ We elaborate these points in detail here:
       - 6385 --> for ironic-endpoint
       - 9999 --> for ironic-ipa
 
-3. The webserver container containing node images volume should be
+1. The webserver container containing node images volume should be
    running and reachable. It is called the `httpd-infra` container in
    metal3-dev-env, which runs on ironic image and contains the node
    images (OS images). It also caches a few other packages which are
@@ -63,7 +63,7 @@ We elaborate these points in detail here:
    └── tmp
    ```
 
-4. The environments variables defined in `ironic-bmo-configmap`
+1. The environments variables defined in `ironic-bmo-configmap`
    required for `Baremetal Operator` deployment needs to be defined
    prior to deploying the provider components in management cluster:
 

--- a/docs/presentations/README.md
+++ b/docs/presentations/README.md
@@ -27,7 +27,7 @@ options:
 
 1. Copy the `dist` and `plugin` directories from revealjs repository to the
    presentations directory.
-2. Copy all the presentation files under the revealjs repository and open the
+1. Copy all the presentation files under the revealjs repository and open the
    presentation `.html` file inside a browser.
 
 Here is an example :

--- a/docs/user-guide/src/bmo/install_baremetal_operator.md
+++ b/docs/user-guide/src/bmo/install_baremetal_operator.md
@@ -5,8 +5,8 @@
 Installing Baremetal Operator (BMO) involves usually three steps:
 
 1. Clone Metal3 BMO repository `https://github.com/metal3-io/baremetal-operator.git`.
-2. Adapt the configuration settings to your specific needs.
-3. Deploy BMO in the cluster with or without Ironic.
+1. Adapt the configuration settings to your specific needs.
+1. Deploy BMO in the cluster with or without Ironic.
 
 *Note*: This guide assumes that a local clone of the repository is available.
 
@@ -69,8 +69,8 @@ It is possible to deploy ```baremetal-operator``` with three different operator
 configurations, namely:
 
 1. operator with ironic
-2. operator without ironic
-3. ironic without operator
+1. operator without ironic
+1. ironic without operator
 
 A detailed overview of the configuration is presented in the following sections.
 
@@ -129,9 +129,9 @@ Operator(BMO) with or without Ironic as well as deploying only Ironic scenario.
 
 1. Deploying baremetal-operator with Ironic.
 
-2. Deploying baremetal-operator without Ironic.
+1. Deploying baremetal-operator without Ironic.
 
-3. Deploying only Ironic.
+1. Deploying only Ironic.
 
 ### Current structure of baremetal-operator config directory
 
@@ -322,10 +322,10 @@ useful as well. For example:
    [(CAPM3)](https://github.com/metal3-io/cluster-api-provider-metal3) when
    a successful pivoting state was met and ironic being deployed.
 
-2. BMO and Ironic are deployed together, in a case when CAPM3 is not used and
+1. BMO and Ironic are deployed together, in a case when CAPM3 is not used and
    baremetal-operator and ironic containers to be deployed together.
 
-3. Only Ironic is deployed, in a case when BMO is deployed as part of CAPM3 and
+1. Only Ironic is deployed, in a case when BMO is deployed as part of CAPM3 and
    only Ironic setup is sufficient, e.g.
    [clusterctl](https://cluster-api.sigs.k8s.io/clusterctl/commands/move.html)
    provided by Cluster API(CAPI) deploys BMO, so that it can take care of moving

--- a/docs/user-guide/src/bmo/instance_customization.md
+++ b/docs/user-guide/src/bmo/instance_customization.md
@@ -30,7 +30,7 @@ This approach has two major downsides:
 
 1. Per-host images take a lot of disk space, especially since Ironic has a
    local image cache.
-2. *diskimage-builder* allows only basic customization out of box, code will
+1. *diskimage-builder* allows only basic customization out of box, code will
    need to be written for anything complex.
 
 It is recommended to use [UserData](#userdata) or [NetworkData](#networkdata)

--- a/docs/user-guide/src/bmo/introduction.md
+++ b/docs/user-guide/src/bmo/introduction.md
@@ -24,14 +24,14 @@ the following properties:
 
 1. The IP address and credentials of the BMC - the remote management controller
    of the host.
-2. The protocol that the BMC understands. Most common are IPMI and Redfish.
+1. The protocol that the BMC understands. Most common are IPMI and Redfish.
    See [supported hardware](supported_hardware) for more details.
-3. Boot technology that can be used with the host and the chosen protocol.
+1. Boot technology that can be used with the host and the chosen protocol.
    Most hardware can use network booting, but some Redfish implementations also
    support virtual media (CD) boot.
-4. MAC address that is used for booting. **Important:** it's a MAC address of
+1. MAC address that is used for booting. **Important:** it's a MAC address of
    an actual NIC of the host, not the BMC MAC address.
-5. The desired boot mode: UEFI or legacy BIOS. UEFI is the default and should
+1. The desired boot mode: UEFI or legacy BIOS. UEFI is the default and should
    be used unless there are serious reasons not to.
 
 This is a minimal example of a valid BareMetalHost:
@@ -62,12 +62,12 @@ To provision a bare-metal machine, you will need a few more properties:
    [Ubuntu](https://cloud-images.ubuntu.com/) or
    [CentOS](https://cloud.centos.org/centos/). **Important:** not all images
    are compatible with UEFI boot - check their description.
-2. Optionally, user data: a secret with a configuration or a script that is
+1. Optionally, user data: a secret with a configuration or a script that is
    interpreted by the first-boot service embedded in your image. The most
    common service is
    [cloud-init](https://cloudinit.readthedocs.io/en/latest/index.html), some
    distributions use [ignition](https://coreos.github.io/ignition/).
-3. Optionally, network data: a secret with the network configuration that is
+1. Optionally, network data: a secret with the network configuration that is
    interpreted by the first-boot service. In some cases, the network data is
    embedded in the user data instead.
 

--- a/docs/user-guide/src/bmo/provisioning.md
+++ b/docs/user-guide/src/bmo/provisioning.md
@@ -20,7 +20,7 @@ document.
 To start the provisioning process, you need at least two bits of information:
 
 1. the URL of the image you want to put on the target host,
-2. the value or the URL of the image checksum using either SHA256 or SHA512
+1. the value or the URL of the image checksum using either SHA256 or SHA512
    (MD5 is supported but deprecated and not compatible with FIPS 140 mode).
 
 The minimum example looks like this:
@@ -47,8 +47,8 @@ In most real cases, you will also want to provide
 
 1. first-boot configuration as described in [instance
    customization](./instance_customization.md),
-2. [hints to choose the target root device](./root_device_hints.md),
-3. the format of the image you use.
+1. [hints to choose the target root device](./root_device_hints.md),
+1. the format of the image you use.
 
 As a result, a more complete example will look like this:
 

--- a/docs/user-guide/src/bmo/supported_hardware.md
+++ b/docs/user-guide/src/bmo/supported_hardware.md
@@ -13,7 +13,7 @@ the two boot methods must be supported:
    network* for isolated L2 traffic between the Metal3 control plane and the
    machines.
 
-2. Virtual media boot. Some hardware model support directly booting an ISO 9660
+1. Virtual media boot. Some hardware model support directly booting an ISO 9660
    image as a virtual CD device over HTTP(s). An important benefit of this
    approach is the ability to boot hardware over L3 networks, potentially
    without DHCP at all.

--- a/docs/user-guide/src/capm3/pivoting.md
+++ b/docs/user-guide/src/capm3/pivoting.md
@@ -91,7 +91,7 @@ successfully:
    Moreover, the IP of the BMH might change after the move and the DHCP-leases
    from the management cluster are not moved to target cluster.
 
-2. Before the move process is initialized, it is important to delete the Ironic
+1. Before the move process is initialized, it is important to delete the Ironic
    pod/Ironic containers. If Ironic is deployed in cluster the deployment is named
    `metal3-ironic`, if it is deployed locally outside the cluster then the user
    has to make sure that all of the ironic related containers are correctly deleted.
@@ -101,7 +101,7 @@ successfully:
    Also there would be two dnsmasq existent in the deployment if there would be
    two Ironic deployment which is undesirable.
 
-3. The provisioning bridge where the `ironic-endpoint-IP` is supposed to be
+1. The provisioning bridge where the `ironic-endpoint-IP` is supposed to be
    attached to should have a static IP assignment on it before the Ironic
    pod/containers start to operate in the target cluster. This is important since
    `ironic-endpoint-keepalived` container will only assign the `ironic-endpoint-IP`
@@ -127,10 +127,10 @@ This can now be achieved with the following procedure:
    bootstrap cluster is up and running then the CAPI and provider components
    can be installed with `clusterctl` to the bootstrap cluster.
 
-2. Install Ironic components, namely: ironic, ironic-endpoint-keepalived, httpd
+1. Install Ironic components, namely: ironic, ironic-endpoint-keepalived, httpd
    and dnsmasq.
 
-3. Use clusterctl init to install the provider components
+1. Use clusterctl init to install the provider components
 
    Example:
 
@@ -143,7 +143,7 @@ This can now be achieved with the following procedure:
    and CAPM3 as the infrastructure provider. All of the controllers will be installed
    on namespace `metal3` and they will be watching over objects in namespace `metal3`.
 
-4. Provision target cluster:
+1. Provision target cluster:
 
    Example:
 
@@ -151,13 +151,13 @@ This can now be achieved with the following procedure:
    clusterctl config cluster ... | kubectl apply -f -
    ```
 
-5. Wait for the target management cluster to be up and running and once it is up
+1. Wait for the target management cluster to be up and running and once it is up
  get the kubeconfig for the new target management cluster.
 
-6. Use the new cluster's kubeconfig to install the ironic-components in the
+1. Use the new cluster's kubeconfig to install the ironic-components in the
  target cluster.
 
-7. Use `clusterctl` init with the new cluster's kubeconfig to install the provider
+1. Use `clusterctl` init with the new cluster's kubeconfig to install the provider
  components.
 
     Example:
@@ -167,7 +167,7 @@ This can now be achieved with the following procedure:
     --target-namespace metal3 --watching-namespace metal3
     ```
 
-8. Use `clusterctl` move to move the Cluster API resources from the bootstrap
+1. Use `clusterctl` move to move the Cluster API resources from the bootstrap
  cluster to the target management cluster.
 
     Example:
@@ -176,4 +176,4 @@ This can now be achieved with the following procedure:
     clusterctl move --to-kubeconfig target.yaml -n metal3 -v 10
     ```
 
-9. Delete the bootstrap cluster
+1. Delete the bootstrap cluster

--- a/docs/user-guide/src/developer_environment/tryit.md
+++ b/docs/user-guide/src/developer_environment/tryit.md
@@ -177,7 +177,7 @@ tested on.
 
 1. Host VM/Server on CentOS, while the target can be Ubuntu or CentOS, Cirros,
    or FCOS.
-2. Host VM/Server on Ubuntu, while the target can be Ubuntu or CentOS, Cirros,
+1. Host VM/Server on Ubuntu, while the target can be Ubuntu or CentOS, Cirros,
    or FCOS.
 
 The way the k8s cluster is running in the above two scenarios is different. For
@@ -507,10 +507,10 @@ by just deleting the proper Custom Resources (CR).
 The order of deletion is:
 
 1. Machine objects of the workers
-2. Metal3Machine objects of the workers
-3. Machine objects of the control plane
-4. Metal3Machine objects of the control plane
-5. The cluster object
+1. Metal3Machine objects of the workers
+1. Machine objects of the control plane
+1. Metal3Machine objects of the control plane
+1. The cluster object
 
 An additional detail is that the `Machine` object `test1-workers-bx4wp` is
 controlled by the `test1` `MachineDeployment` the object thus in order to avoid

--- a/docs/user-guide/src/ipam/ipam_installation.md
+++ b/docs/user-guide/src/ipam/ipam_installation.md
@@ -65,7 +65,7 @@ in the **IPPool** object will block the deletion.
 ## References
 
 1. [IPAM](https://github.com/metal3-io/ip-address-manager/).
-2. [IPAM deployment workflow](https://github.com/metal3-io/ip-address-manager/blob/main/docs/deployment_workflow.md).
-3. Custom resource (CR) examples in
+1. [IPAM deployment workflow](https://github.com/metal3-io/ip-address-manager/blob/main/docs/deployment_workflow.md).
+1. Custom resource (CR) examples in
    [metal3-dev-env](https://github.com/metal3-io/metal3-dev-env), in the
    [templates](https://github.com/metal3-io/metal3-dev-env/tree/main/tests/roles/run_tests/templates).

--- a/docs/user-guide/src/ironic/introduction.md
+++ b/docs/user-guide/src/ironic/introduction.md
@@ -104,9 +104,9 @@ host `compute-0` in the `metal3` namespace will receive the Ironic name
 `metal3~compute-0`. If no record is found:
 
 1. A new record is created in Ironic.
-2. BMC credentials are verified by Ironic by reading the current power state of
+1. BMC credentials are verified by Ironic by reading the current power state of
    the machine.
-3. The
+1. The
    [inspection](https://docs.openstack.org/ironic/latest/admin/inspection/index.html)
    process is started.
 
@@ -148,7 +148,7 @@ being immediately removed on deletion. Before the finalizer is removed, the
 host is:
 
 1. cleaned to remove the partitioning tables from all its disks,
-2. powered off to stop it from running the service ramdisk.
+1. powered off to stop it from running the service ramdisk.
 
 The cleaning process is retried several times. If due to a problem with the
 host cleaning is no longer possible, disable cleaning first by setting the

--- a/docs/user-guide/src/irso/database.md
+++ b/docs/user-guide/src/irso/database.md
@@ -70,7 +70,7 @@ follows:
 
    **Note:** a lot of parameters can be tuned here - see official examples.
 
-2. Create the database for Ironic:
+1. Create the database for Ironic:
 
    ```yaml
    apiVersion: k8s.mariadb.com/v1alpha1
@@ -88,7 +88,7 @@ follows:
      collate: utf8_general_ci
    ```
 
-3. Create a user and grant it all privileges to the new database:
+1. Create a user and grant it all privileges to the new database:
 
    ```yaml
    ---
@@ -146,7 +146,7 @@ follows:
    operation of Ironic. The exact value depends on your environment, 100 is the
    value used in the CI.
 
-4. After making sure that all objects are created and in `Ready` state, you can
+1. After making sure that all objects are created and in `Ready` state, you can
    link to the database via its service endpoint:
 
    ```yaml

--- a/processes/managing-reviewers.md
+++ b/processes/managing-reviewers.md
@@ -13,7 +13,7 @@ describes the process for adding reviewers to a metal3 project repo.
 ### Goals
 
 1. Describe a process for adding reviewers.
-2. Keep the process light-weight.
+1. Keep the process light-weight.
 
 ### Non-Goals
 

--- a/processes/reviewer-permissions-migration.md
+++ b/processes/reviewer-permissions-migration.md
@@ -35,8 +35,8 @@ with blanket permissions across all of our repositories.
 ### Non-Goals
 
 1. Define a new process for approving reviewers.
-2. Change the process for approving approvers.
-3. Change the permissions for managing the CI infrastructure.
+1. Change the process for approving approvers.
+1. Change the permissions for managing the CI infrastructure.
 
 ## Proposal
 


### PR DESCRIPTION
We have it in metal3-io wide use except couple lists in BMO, and some old design docs, so enforcing it in config in all repos for consistency.