### PR TITLE
add SECURITY_INSIGHTS.yml

### DIFF
--- a/.github/workflows/validate-security-insights.yml
+++ b/.github/workflows/validate-security-insights.yml
@@ -1,0 +1,23 @@
+name: Validate SECURITY_INSIGHTS.yml
+on:
+  pull_request:
+    paths:
+    - SECURITY_INSIGHTS.yml
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+    - name: Install CUE
+      uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+
+    - name: Fetch Security Insights schema
+      run: |
+        mkdir -p /tmp/si-spec
+        curl -sSfL -o /tmp/si-spec/schema.cue \
+          https://raw.githubusercontent.com/ossf/security-insights/v2.2.0/spec/schema.cue
+
+    - name: Validate schema
+      run: cue vet -d '#SecurityInsights' /tmp/si-spec/schema.cue SECURITY_INSIGHTS.yml

--- a/SECURITY_INSIGHTS.yml
+++ b/SECURITY_INSIGHTS.yml
@@ -1,0 +1,34 @@
+header:
+  schema-version: 2.2.0
+  last-updated: '2026-02-24'
+  last-reviewed: '2026-02-24'
+  url: https://raw.githubusercontent.com/metal3-io/metal3-docs/main/SECURITY_INSIGHTS.yml
+  project-si-source: https://raw.githubusercontent.com/metal3-io/community/main/SECURITY_INSIGHTS.yml
+repository:
+  url: https://github.com/metal3-io/metal3-docs
+  status: active
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  core-team:
+  - name: dtantsur
+    primary: false
+  - name: kashifest
+    primary: true
+  - name: lentzi90
+    primary: false
+  - name: zaneb
+    primary: false
+  documentation:
+    contributing-guide: https://github.com/metal3-io/metal3-docs/blob/main/CONTRIBUTING.md
+    security-policy: https://github.com/metal3-io/.github/blob/main/SECURITY.md
+    governance: https://github.com/metal3-io/community/blob/main/GOVERNANCE.md
+  license:
+    url: https://github.com/metal3-io/metal3-docs/blob/main/LICENSE
+    expression: Apache-2.0
+  security:
+    assessments:
+      self:
+        name: Metal3 Security Self-Assessment
+        date: '2024-11-19'
+        evidence: https://github.com/metal3-io/metal3-docs/blob/main/security/self-assessment.md
+        comment: Project-wide self-assessment covering all Metal3 components.


### PR DESCRIPTION
Add SECURITY_INSIGHTS.yml file and GHA validator for it.

Metal3-docs repo hosts the security self-assessment which other insights files refer to.

Ref: https://github.com/metal3-io/community/issues/43

https://github.com/metal3-io/community/pull/44 must be merged before this. Until it does,
/hold