### PR TITLE
Add Ironic Standalone Operators(IrSO) version support

### DIFF
--- a/docs/user-guide/src/irso/introduction.md
+++ b/docs/user-guide/src/irso/introduction.md
@@ -85,23 +85,5 @@ With Keepalived support enabled:
 
 ### Supported versions
 
-A major and minor version can be supplied to the `Ironic` resource to request
-a specific branch of ironic-image (and thus Ironic). Here are supported version
-values for each branch and release of the operator:
-
-| Operator version | Ironic version(s)                    | Default version | Support status |
-| ---------------- | ------------------------------------ | --------------- | -------------- |
-| latest (main)    | latest, 34.0, 33.0, 32.0             | latest          | Supported      |
-| 0.8.0            | 34.0, 33.0, 32.0                     | 34.0            | Supported      |
-| 0.7.0            | 33.0, 32,0, 31.0                     | 33.0            | Supported      |
-| 0.6.0            | 32.0, 31.0, 30.0                     | 32.0            | EOL            |
-| 0.5.0            | 31.0, 30.0, 29.0, 28.0, 27.0         | 31.0            | EOL            |
-| 0.4.0            | 30.0, 29.0, 28.0, 27.0               | 30.0            | EOL            |
-| 0.3.0            | 29.0, 28.0, 27.0                     | latest          | EOL            |
-| 0.2.0            | 28.0, 27.0                           | latest          | EOL            |
-| 0.1.0            | 27.0                                 | latest          | EOL            |
-
-**NOTE:** the special version value `latest` always installs the latest
-available version of ironic-image and Ironic. This version value is
-supported by all releases of IrSO but only works reliably in the
-latest release.
+See the [supported release versions](../version_support.md#ironic-standalone-operator)
+page for information on which versions of IrSO are currently supported.

--- a/docs/user-guide/src/version_support.md
+++ b/docs/user-guide/src/version_support.md
@@ -94,6 +94,31 @@ Following table summarizes Ironic-image release/test process:
 | v24.0         | EOL       | bugfix/24.0 (EOL)   |
 | v23.1         | EOL       | bugfix/23.1 (EOL)   |
 
+## Ironic Standalone Operator
+
+Ironic Standalone Operator (IrSO) follows the semantic versioning scheme for its
+own release cycle, the same way as CAPM3 and IPAM. A major and minor version can
+be supplied to the `Ironic` resource to request a specific branch of ironic-image
+(and thus Ironic). Here are supported version values for each branch and release
+of the operator:
+
+| Operator version | Ironic version(s)                    | Default version | Support status |
+| ---------------- | ------------------------------------ | --------------- | -------------- |
+| latest (main)    | latest, 34.0, 33.0, 32.0             | latest          | Supported      |
+| 0.8.0            | 34.0, 33.0, 32.0                     | 34.0            | Supported      |
+| 0.7.0            | 33.0, 32,0, 31.0                     | 33.0            | Supported      |
+| 0.6.0            | 32.0, 31.0, 30.0                     | 32.0            | EOL            |
+| 0.5.0            | 31.0, 30.0, 29.0, 28.0, 27.0         | 31.0            | EOL            |
+| 0.4.0            | 30.0, 29.0, 28.0, 27.0               | 30.0            | EOL            |
+| 0.3.0            | 29.0, 28.0, 27.0                     | latest          | EOL            |
+| 0.2.0            | 28.0, 27.0                           | latest          | EOL            |
+| 0.1.0            | 27.0                                 | latest          | EOL            |
+
+**NOTE:** the special version value `latest` always installs the latest
+available version of ironic-image and Ironic. This version value is
+supported by all releases of IrSO but only works reliably in the
+latest release.
+
 ## Image tags
 
 The Metal³ team provides container images for all the main projects and also


### PR DESCRIPTION
This PR adds IrSO version support table. Although we dont have any periodics running on the branches, the table tries to tie the test and support of IrSO to ironic-image support