### PR TITLE
docs: Add Fast Track documentation

### DIFF
--- a/docs/user-guide/src/SUMMARY.md
+++ b/docs/user-guide/src/SUMMARY.md
@@ -59,6 +59,8 @@
       - [Annotation-based IPPool](capm3/annotation_based_ippool.md)
       - [Controller pod placement](capm3/pod_placement.md)
       - [ProviderID Workflow](capm3/providerid-workflow.md)
+      - [Fast Track](capm3/fast_track.md)
+      - [IP Reuse](capm3/ip_reuse.md)
 - [Ip-address-manager](ipam/introduction.md)
    - [Install Ip-address-manager](ipam/ipam_installation.md)
 - [Troubleshooting FAQ](troubleshooting.md)

--- a/docs/user-guide/src/SUMMARY.md
+++ b/docs/user-guide/src/SUMMARY.md
@@ -60,6 +60,7 @@
       - [Annotation-based IPPool](capm3/annotation_based_ippool.md)
       - [Controller pod placement](capm3/pod_placement.md)
       - [ProviderID Workflow](capm3/providerid-workflow.md)
+      - [Fast Track](capm3/fast_track.md)
 - [Ip-address-manager](ipam/introduction.md)
    - [Install Ip-address-manager](ipam/ipam_installation.md)
 - [Troubleshooting FAQ](troubleshooting.md)

--- a/docs/user-guide/src/capm3/fast_track.md
+++ b/docs/user-guide/src/capm3/fast_track.md
@@ -1,0 +1,151 @@
+# Fast Track Mode
+
+## Overview
+
+Fast Track mode is an optimization feature in CAPM3 that allows BareMetalHosts
+to skip the deprovisioning power-off cycle during machine deletion when certain
+conditions are met. This can significantly speed up cluster upgrades and node
+replacements by keeping hosts powered on and ready for immediate re-use.
+
+## How It Works
+
+When a Metal3Machine is deleted, CAPM3 normally instructs the BareMetalHost to
+power off and deprovision. With Fast Track mode enabled, CAPM3 can keep the host
+powered on if automated cleaning is configured to only clean metadata.
+
+The behavior is controlled by three factors:
+
+1. **BareMetalHost.Spec.DisablePowerOff**: If `true`, the host always stays
+   online (highest priority)
+1. **CAPM3_FAST_TRACK environment variable**: Set to `true` or `false`
+1. **BareMetalHost.Spec.AutomatedCleaningMode**: Set to `disabled` or `metadata`
+
+### Behavior Matrix
+
+| DisablePowerOff | CAPM3_FAST_TRACK | AutomatedCleaningMode | BMH Online Status        |
+| --------------- | ---------------- | --------------------- | ------------------------ |
+| true            | any              | any                   | **On** (DisablePowerOff) |
+| false           | false            | disabled              | Off                      |
+| false           | true             | disabled              | Off                      |
+| false           | false            | metadata              | Off                      |
+| false           | true             | metadata              | **On** (Fast Track)      |
+
+Since PR #3106 (`Allow disable_power_off together with autoclean`, merged on
+2026-03-05), `DisablePowerOff=true` can be combined with
+`AutomatedCleaningMode=metadata`. In that case, `DisablePowerOff` still takes
+priority and keeps the host online.
+
+The host remains online when:
+
+- `DisablePowerOff` is `true` (takes priority over all other settings), or
+- `AutomatedCleaningMode` is set to `metadata` (not `disabled`) AND
+  `CAPM3_FAST_TRACK` is set to `true`
+
+When both conditions are met, the BareMetalHost remains powered on after the
+Metal3Machine is deleted, allowing it to be quickly re-claimed by a new
+Metal3Machine without waiting for a full power cycle.
+
+## When to Use Fast Track
+
+Fast Track is beneficial in scenarios where:
+
+- **Rolling upgrades**: Nodes are being replaced one at a time, and speed is
+  important
+- **Controlled environments**: You trust that metadata cleaning is sufficient
+  (no need for full disk wipes)
+- **Development/testing**: Quick iteration cycles where full deprovisioning
+  adds unnecessary delay
+
+Fast Track should be avoided when:
+
+- **Security is paramount**: Full disk wiping is required between tenants or
+  workloads
+- **Disk cleaning is needed**: The `disabled` AutomatedCleaningMode is used
+  intentionally
+- **Troubleshooting**: You need hosts to fully deprovision to reset state
+
+## Configuration
+
+### Enabling Fast Track
+
+Fast Track is configured via the `CAPM3_FAST_TRACK` environment variable on the
+CAPM3 controller. It defaults to `false`.
+
+#### Via clusterctl
+
+Add to your clusterctl configuration file:
+
+```yaml
+variables:
+  CAPM3_FAST_TRACK: "true"
+```
+
+#### Via Environment Variable
+
+If deploying the controller directly, set the environment variable:
+
+```bash
+export CAPM3_FAST_TRACK=true
+```
+
+### Configuring AutomatedCleaningMode
+
+For Fast Track to work, your BareMetalHost resources must have
+`AutomatedCleaningMode` set to `metadata`. This can also be combined with
+`DisablePowerOff=true`; in that case `DisablePowerOff` remains the deciding
+factor for keeping the host online. Refer to the
+[Baremetal Operator Documentation](https://book.metal3.io/bmo/introduction)
+for details on configuring this field.
+
+## Behavior During Machine Deletion
+
+When a Metal3Machine is being deleted:
+
+1. CAPM3 clears the BareMetalHost's image, customDeploy, userData, metaData,
+   and networkData references
+1. Based on the AutomatedCleaningMode and CAPM3_FAST_TRACK values, CAPM3 sets
+   the BMH's `Online` field:
+   - **Fast Track active**: Host stays online (`Online: true`)
+   - **Fast Track inactive**: Host is powered off (`Online: false`)
+1. CAPM3 waits for the host to reach an available state before fully releasing
+   it
+1. The ConsumerRef and other association data are cleared
+
+## Monitoring
+
+When Fast Track is active, you'll see log messages like:
+
+```text
+Set host Online field based on DisablePowerOff, AutomatedCleaningMode, and Capm3FastTrack host=node-0 automatedCleaningMode=metadata hostSpecOnline=true
+```
+
+When Fast Track keeps a host online, the BareMetalHost will transition directly
+from `Provisioned` to `Available` without going through `Deprovisioning` with a
+power-off cycle.
+
+## Troubleshooting
+
+### Host Not Staying Online
+
+If hosts are being powered off despite Fast Track being enabled:
+
+1. Verify `CAPM3_FAST_TRACK` is set to `true` (not `True` or `1`)
+1. Check that `AutomatedCleaningMode` is `metadata`, not `disabled`
+1. Review controller logs for the decision logic
+
+### Host Stuck in Deprovisioning
+
+If a host appears stuck, it may be waiting for cleaning to complete. Check:
+
+1. The Ironic conductor logs for cleaning status
+1. The BareMetalHost status for any error messages
+1. Whether the host's BMC is accessible
+
+## Related Documentation
+
+- [Automated Cleaning](./automated_cleaning.md) - Details on automated cleaning
+  modes
+- [IP Reuse](./ip_reuse.md) - Related feature for predictable IP allocation
+  during upgrades
+- [Baremetal Operator Automated Cleaning](../bmo/automated_cleaning.md) - BMH
+  lifecycle and cleaning modes

--- a/docs/user-guide/src/capm3/fast_track.md
+++ b/docs/user-guide/src/capm3/fast_track.md
@@ -1,0 +1,173 @@
+# Fast Track Mode
+
+## Overview
+
+Fast Track mode is an optimization feature in CAPM3 that keeps BareMetalHosts
+powered on during machine deletion when certain conditions are met. This can
+significantly speed up cluster upgrades and node replacements by avoiding an
+extra power cycle before the host is re-used.
+
+CAPM3 Fast Track is different from Ironic Fast Track. Ironic Fast Track reuses
+an already-running agent ramdisk across Ironic inspection, cleaning, and
+deployment. CAPM3 Fast Track controls whether CAPM3 leaves the BareMetalHost
+`Online` during Metal3Machine deletion. These features are commonly used
+together in Metal3, but enabling one does not enable the other.
+
+## How It Works
+
+When a Metal3Machine is deleted, CAPM3 normally lets the BareMetalHost power off
+as part of deprovisioning. With Fast Track enabled, CAPM3 can keep the host
+powered on when automated cleaning is not disabled.
+
+When automated cleaning is enabled, the physical machine boots into the Ironic
+Python Agent to run cleaning. CAPM3 Fast Track keeps the machine running with
+the agent after cleaning completes, which saves one reboot when the host is
+re-provisioned.
+
+The behavior is controlled by three factors:
+
+1. **BareMetalHost.Spec.DisablePowerOff**: If `true`, the host always stays
+   online (highest priority)
+1. **CAPM3_FAST_TRACK environment variable**: Set to `true` or `false`
+1. **BareMetalHost.Spec.AutomatedCleaningMode**: Set to `disabled` or a
+   cleaning-enabled mode such as `metadata`
+
+### Behavior Matrix
+
+| DisablePowerOff | CAPM3_FAST_TRACK | AutomatedCleaningMode         | BMH Online Status        |
+| --------------- | ---------------- | ----------------------------- | ------------------------ |
+| true            | any              | any                           | **On** (DisablePowerOff) |
+| false           | false            | disabled                      | Off                      |
+| false           | true             | disabled                      | Off                      |
+| false           | false            | not disabled (metadata today) | Off                      |
+| false           | true             | not disabled (metadata today) | **On** (Fast Track)      |
+
+Since PR #3106 (`Allow disable_power_off together with autoclean`, merged on
+2026-03-05), `DisablePowerOff=true` can be combined with
+`AutomatedCleaningMode=metadata`. In that case, `DisablePowerOff` still takes
+priority and keeps the host online.
+
+The host remains online when:
+
+- `DisablePowerOff` is `true` (takes priority over all other settings), or
+- `AutomatedCleaningMode` is not `disabled` AND
+  `CAPM3_FAST_TRACK` is set to `true`
+
+When both conditions are met, the BareMetalHost remains powered on after the
+Metal3Machine is deleted, allowing it to be quickly re-claimed by a new
+Metal3Machine without waiting for a full power cycle.
+
+## When to Use Fast Track
+
+Fast Track is beneficial when BareMetalHosts are expected to be re-used and
+power consumption is not a limiting factor, for example:
+
+- **Rolling upgrades**: Nodes are being replaced one at a time, and speed is
+  important
+- **Development/testing**: Quick iteration cycles where full deprovisioning
+  adds unnecessary delay
+- **Predictable host reuse**: Reusing the same physical hosts is part of the
+  normal operating model
+
+Fast Track is less useful, or should be disabled, when:
+
+- **Hosts should remain powered off**: Power consumption, cooling, or rack
+  operations require unused machines to be off
+- **Physical maintenance is planned**: Hardware replacement or other service
+  work requires the machine to be powered off
+- **Automated cleaning is disabled intentionally**:
+  `AutomatedCleaningMode=disabled` makes CAPM3 power off the host
+
+## Configuration
+
+### Enabling Fast Track
+
+Fast Track is configured via the `CAPM3_FAST_TRACK` environment variable on the
+CAPM3 controller. It defaults to `false`.
+
+#### Via clusterctl
+
+Add to your clusterctl configuration file:
+
+```yaml
+variables:
+  CAPM3_FAST_TRACK: "true"
+```
+
+#### Via Environment Variable
+
+If deploying the controller directly, set the environment variable:
+
+```bash
+export CAPM3_FAST_TRACK=true
+```
+
+### Configuring AutomatedCleaningMode
+
+For Fast Track to work, automated cleaning must not be disabled. Today the
+documented CAPM3 cleaning-enabled value is `metadata`, and CAPM3's deletion
+logic treats any value other than `disabled` as eligible for Fast Track.
+
+In CAPM3 workflows, configure automated cleaning through the
+Metal3MachineTemplate or Metal3Machine fields described in the
+[CAPM3 automated cleaning documentation](./automated_cleaning.md), and let CAPM3
+replicate the setting to the BareMetalHost. This can also be combined with
+`DisablePowerOff=true`; in that case `DisablePowerOff` remains the deciding
+factor for keeping the host online.
+
+## Behavior During Machine Deletion
+
+When a Metal3Machine is being deleted:
+
+1. CAPM3 clears the BareMetalHost's image, customDeploy, userData, metaData,
+   and networkData references
+1. Based on the DisablePowerOff, AutomatedCleaningMode, and CAPM3_FAST_TRACK
+   values, CAPM3 sets the BMH's `Online` field:
+   - **Fast Track active**: The host stays online (`Online: true`) while
+     deprovisioning and cleaning complete
+   - **Fast Track inactive**: The host is powered off (`Online: false`) as part
+     of deprovisioning
+1. CAPM3 waits for the host to reach an available state before fully releasing
+   it
+1. The ConsumerRef and other association data are cleared
+
+Fast Track does not skip BMO or Ironic deprovisioning. It avoids the extra
+power-off and power-on cycle when a cleaned host will be re-used.
+
+## Monitoring
+
+When Fast Track is active, CAPM3 produces log messages like:
+
+```text
+Set host Online field based on DisablePowerOff, AutomatedCleaningMode, and Capm3FastTrack host=node-0 automatedCleaningMode=metadata hostSpecOnline=true
+```
+
+When Fast Track keeps a host online, the BareMetalHost still deprovisions and
+runs cleaning. The difference is that the host remains `Online`, so the next
+Metal3Machine can claim it without waiting for another power-on boot.
+
+## Troubleshooting
+
+### Host Not Staying Online
+
+If hosts are being powered off despite Fast Track being enabled:
+
+1. Verify `CAPM3_FAST_TRACK` is set to `true` (not `True` or `1`)
+1. Check that `AutomatedCleaningMode` is not `disabled` (`metadata` in current
+   CAPM3 documentation)
+1. Review controller logs for the decision logic
+
+### Host Stuck in Deprovisioning
+
+If a host appears stuck, it may be waiting for cleaning to complete. Check:
+
+1. The Ironic conductor logs for cleaning status
+1. The BareMetalHost status for any error messages
+1. Whether the host's BMC is accessible
+
+## Related Documentation
+
+- [Automated Cleaning](./automated_cleaning.md) - Details on automated cleaning
+  modes
+- [Baremetal Operator Automated Cleaning](../bmo/automated_cleaning.md) - BMH
+  lifecycle and cleaning modes

--- a/docs/user-guide/src/capm3/fast_track.md
+++ b/docs/user-guide/src/capm3/fast_track.md
@@ -17,7 +17,7 @@ together in Metal3, but enabling one does not enable the other.
 
 When a Metal3Machine is deleted, CAPM3 normally lets the BareMetalHost power off
 as part of deprovisioning. With Fast Track enabled, CAPM3 can keep the host
-powered on when automated cleaning is not disabled.
+powered on when automated cleaning is set to any value other than `disabled`.
 
 When automated cleaning is enabled, the physical machine boots into the Ironic
 Python Agent to run cleaning. CAPM3 Fast Track keeps the machine running with
@@ -42,8 +42,7 @@ The behavior is controlled by three factors:
 | false           | false            | not disabled (metadata today) | Off                      |
 | false           | true             | not disabled (metadata today) | **On** (Fast Track)      |
 
-Since PR #3106 (`Allow disable_power_off together with autoclean`, merged on
-2026-03-05), `DisablePowerOff=true` can be combined with
+Starting with CAPM3 v1.13.0, `DisablePowerOff=true` can be combined with
 `AutomatedCleaningMode=metadata`. In that case, `DisablePowerOff` still takes
 priority and keeps the host online.
 
@@ -59,8 +58,8 @@ Metal3Machine without waiting for a full power cycle.
 
 ## When to Use Fast Track
 
-Fast Track is beneficial when BareMetalHosts are expected to be re-used and
-power consumption is not a limiting factor, for example:
+Fast Track is beneficial in use cases where BareMetalHosts are expected to be
+re-used eventually and power consumption is not a factor, for example:
 
 - **Rolling upgrades**: Nodes are being replaced one at a time, and speed is
   important

--- a/docs/user-guide/src/capm3/features.md
+++ b/docs/user-guide/src/capm3/features.md
@@ -10,3 +10,5 @@
 - [Failure domain](./failure_domain.md)
 - [Annotation-based IPPool](./annotation_based_ippool.md)
 - [Controller pod placement](./pod_placement.md)
+- [Fast Track](./fast_track.md)
+- [IP Reuse](./ip_reuse.md)

--- a/docs/user-guide/src/capm3/features.md
+++ b/docs/user-guide/src/capm3/features.md
@@ -10,3 +10,4 @@
 - [Failure domain](./failure_domain.md)
 - [Annotation-based IPPool](./annotation_based_ippool.md)
 - [Controller pod placement](./pod_placement.md)
+- [Fast Track](./fast_track.md)

--- a/docs/user-guide/src/capm3/ip_reuse.md
+++ b/docs/user-guide/src/capm3/ip_reuse.md
@@ -1,0 +1,187 @@
+# IP Reuse (BMH Name-Based Preallocation)
+
+## Overview
+
+IP reuse, also known as BMH Name-Based Preallocation, is a feature that enables
+predictable IP address assignment to BareMetalHosts. This is particularly useful
+during rolling upgrades where you want nodes to retain their IP addresses even
+as the underlying Metal3Machine and Metal3Data objects are recreated.
+
+## Default Behavior (Without BMH Name-Based Preallocation)
+
+As is now, IPPool is an object representing a set of IPAddress pools to be used
+for IPAddress allocations. An IPClaim is an object representing a request for an
+IPAddress allocation. Consequently, the IPClaim object name is structured as
+following:
+
+**IPClaimName** = **Metal3DataName** + **(-)** + **IPPoolName**
+
+Example: metal3datatemplate-0-pool0
+
+The `Metal3DataName` is derived from the `Metal3DataTemplateName` with an added
+index (`Metal3DataTemplateName-index`), and the `IPPoolName` comes from the
+IPPool object directly. (See the
+[IP Address manager](../ipam/introduction.md)
+for more details on these objects). In the CAPM3 workflow, when a Metal3Machine
+is created and a Metal3Data object is requested, the process of choosing an
+`index` to be appended to the name of the `Metal3DataTemplateName`, is random.
+For example, let's imagine we have two Metal3Machines: `metal3machine-0` and
+`metal3machine-1` which creates the following `metal3datatemplate-0` and
+`metal3datatemplate-1` Metal3Data objects respectively. However, if two nodes
+are being upgraded at a time, there is no guarantee that same indices will be
+appended to the respective objects and in fact it can be in completely reverse
+order (i.e. `metal3machine-0` will get `m3datatemplate-1` and `metal3machine-1`
+will get `m3datatemplate-0`). In order to make it predictable, we structure
+IPClaim object name using the BareMetalHost name, as following:
+
+**IPClaimName** = **BareMetalHostName** + **(-)** + **IPPoolName**
+
+Example: node-0-pool0
+
+Now, the first part consists of `BareMetalHostName` which is the name of the
+BareMetalHost object, and should always stay the same once created
+(predictable). The second part of it is kept unchanged.
+
+## What is the use of PreAllocations field
+
+Once we have a predictable `IPClaimName`, we can make use of a
+`PreAllocations map[string]IPAddressStr` field in the IPPool object to achieve
+our goal.
+
+We simply add the claim name(s) using the new format (BareMetalHost name
+included) to the `preAllocations` field in the `IPPool`, i.e:
+
+```yaml
+apiVersion: ipam.metal3.io/v1alpha1
+kind: IPPool
+metadata:
+  name: baremetalv4-pool
+  namespace: metal3
+spec:
+  clusterName: test1
+  gateway: 192.168.111.1
+  namePrefix: test1-bmv4
+  pools:
+  - end: 192.168.111.200
+    start: 192.168.111.100
+  prefix: 24
+  preAllocations:
+    node-0-pool0: 192.168.111.101
+    node-1-pool0: 192.168.111.102
+status:
+  indexes:
+    node-0-pool0: 192.168.111.101
+    node-1-pool0: 192.168.111.102
+```
+
+Since claim names include BareMetalHost names on them, we are able to predict an
+IPAddress assigned to the specific node.
+
+## How to Enable BMH Name-Based Preallocation
+
+To enable the feature, a boolean flag called `enable-bmh-name-based-preallocation`
+was added. It is configurable via clusterctl and it can be passed to the
+clusterctl configuration file by the user.
+
+### Via clusterctl Configuration
+
+Add to your `"${XDG_CONFIG_HOME}"/.config/cluster-api/clusterctl.yaml`:
+
+```yaml
+variables:
+  ENABLE_BMH_NAME_BASED_PREALLOCATION: "true"
+```
+
+### Via Controller Flag
+
+The CAPM3 controller accepts a flag:
+
+```bash
+--enable-bmh-name-based-preallocation=true
+```
+
+This flag enables the BMH name-based IPClaim naming scheme.
+
+## Use Cases
+
+### Rolling Upgrades with Stable IPs
+
+When performing a rolling upgrade of your cluster:
+
+1. Each BareMetalHost has a stable name (e.g., `node-0`, `node-1`)
+1. With preallocation enabled, IPClaims are named using the BMH name
+1. Pre-populate the IPPool's `preAllocations` field with the desired mappings
+1. As nodes are upgraded, they automatically receive their pre-assigned IPs
+
+### DNS and Certificate Management
+
+Stable IP addresses simplify:
+
+- DNS record management (no need to update records after upgrades)
+- Certificate provisioning (certificates tied to specific IPs remain valid)
+- Firewall rules (static IP-based rules don't need updates)
+
+### Multi-Cluster Deployments
+
+When managing multiple clusters, predictable IPs help with:
+
+- Network segmentation and planning
+- Monitoring and alerting configurations
+- Load balancer backend configurations
+
+## Interaction with Metal3Data Labels
+
+When BMH name-based preallocation is enabled, additional labels are added to
+Metal3Data objects to track the association:
+
+- `infrastructure.cluster.x-k8s.io/data-name` (`DataLabelName`) stores the
+  Metal3Data name
+- `infrastructure.cluster.x-k8s.io/pool-name` (`PoolLabelName`) stores the
+  referenced pool name
+
+These labels make it possible to track which Metal3Data object and pool were
+used for a given allocation.
+
+## Considerations
+
+### BareMetalHost Naming
+
+For this feature to work effectively:
+
+- BareMetalHost names must be stable and predictable
+- Avoid using generated names that change between deployments
+- Use meaningful names that reflect the physical hardware (e.g., rack position)
+
+### IPPool Configuration
+
+When setting up preAllocations:
+
+- The claim name format is: `{bmh-name}-{pool-name}`
+- Ensure all expected BMH names are covered in the preAllocations map
+- IPs in preAllocations are reserved and won't be allocated to other claims
+
+### Cleanup
+
+When a Metal3Machine is deleted:
+
+- The IPClaim is released
+- The preallocated IP remains reserved in the pool
+- When a new Metal3Machine claims the same BMH, it gets the same IP
+
+## Troubleshooting
+
+### IP Not Being Reused
+
+1. Verify `--enable-bmh-name-based-preallocation` or
+   `ENABLE_BMH_NAME_BASED_PREALLOCATION` is enabled
+1. Check that the IPPool `preAllocations` field includes the correct mapping
+1. Verify the claim name format matches: `{bmh-name}-{pool-name}`
+
+### IPClaim Name Mismatch
+
+If IPClaims are not using BMH names:
+
+1. Check controller logs for preallocation-related messages
+1. Verify the `--enable-bmh-name-based-preallocation` flag is properly set on
+   the controller deployment
+1. Restart the controller after changing the configuration


### PR DESCRIPTION
Update the Metal3 book with CAPM3 Fast Track documentation.

Changes:
- Add Fast Track mode behavior matrix and configuration.
- Clarify CAPM3 Fast Track vs Ironic Fast Track.
- Document DisablePowerOff and automated cleaning interactions, including CAPM3 PR #3106 behavior.
- Add monitoring and troubleshooting guidance.

IP reuse was split to #700.

Related: metal3-io/cluster-api-provider-metal3#3111
