### PR TITLE
Fix broken links reported in issue #693

### DIFF
--- a/design/metadata-handling.md
+++ b/design/metadata-handling.md
@@ -408,7 +408,7 @@ while `networkData` will be rendered into a map equivalent of
 [Nova network_data.json](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata).
 On the target node, the network data will be rendered as a json object that
 follows the format definition that can be found
-[over here](https://docs.openstack.org/nova/latest/_downloads/9119ca7ac90aa2990e762c08baea3a36/network_data.json).
+[over here](https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json).
 
 #### Metadata Specifications
 

--- a/docs/user-guide/src/bmo/instance_customization.md
+++ b/docs/user-guide/src/bmo/instance_customization.md
@@ -79,7 +79,7 @@ spec:
 ```
 
 [network_data]: https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata
-[network_data schema]: https://docs.openstack.org/nova/latest/_downloads/9119ca7ac90aa2990e762c08baea3a36/network_data.json
+[network_data schema]: https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json
 
 ### NetworkData examples
 

--- a/docs/user-guide/src/capm3/metal3machine.md
+++ b/docs/user-guide/src/capm3/metal3machine.md
@@ -36,7 +36,7 @@ The fields are:
   [doc](https://cluster-api.sigs.k8s.io/developer/providers/contracts/clusterctl#ownerreferences-chain)).
   The content of the secret should be a yaml equivalent of a json object that
   follows the format definition that can be found
-  [here](https://docs.openstack.org/nova/latest/_downloads/9119ca7ac90aa2990e762c08baea3a36/network_data.json).
+  [here](https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json).
 
 - **hostSelector** -- Specify criteria for matching labels on `BareMetalHost`
   objects. This can be used to limit the set of available `BareMetalHost`

--- a/processes/releasing.md
+++ b/processes/releasing.md
@@ -24,46 +24,6 @@ repos.
 **NOTE**: Always follow release documentation from the respective main branch.
 Release documentation in release branches may be outdated.
 
-## Tag Mariadb image
-
-**NOTE**: This step is deprecated and is applied only up to CAPM3 v1.11.x tags.
-
-After releasing `v1.x.y` version of CAPM3, create an annotated tag with `capm3-`
-prefix + release version in
-[mariadb-image](https://github.com/metal3-io/mariadb-image) Github repository.
-Origin points to `metal3-io`.
-
-For minor releases:
-
-```bash
-git tag -s -a capm3-v1.x.y -m capm3-v1.x.y
-git push origin capm3-v1.x.y
-```
-
-For patch releases:
-
-```bash
-git tag -s -a capm3-v1.x.y -m capm3-v1.x.y [optional sha, or tag^{}]
-git push origin capm3-v1.x.y
-```
-
-The last part should point to a previous patch. For example for tag `v.1.x.2`:
-
-```bash
-git tag -s -a capm3-v1.x.2 -m capm3-v1.x.2 capm3-v1.x.1^{}
-```
-
-After this, [MariaDB](https://quay.io/repository/metal3-io/mariadb) container
-image will be built automatically  with `capm3-v1.x.y` tag in Quay. Verify the
-build is triggered, as often Quay has disabled the build trigger due build
-failures or other reasons.
-
-If build is not triggered check:
-
-- Debug and retrigger [workflow](https://github.com/metal3-io/mariadb-image/actions/runs/13174700659/job/36772849955)
-for building container images
-- You can also try running the job in [Jenkins](https://jenkins.nordix.org/view/Metal3/job/metal3_mariadb_container_image_building/)
-
 ## Update Metal3 dev-env and CI to support new releases
 
 If a new minor or major release was published, we need to make changes in


### PR DESCRIPTION
## Summary
Addresses broken links reported in [#693](https://github.com/metal3-io/metal3-docs/issues/693).

**This commit — mariadb-image (`processes/releasing.md`)**
- Remove the obsolete "Tag Mariadb image" section
- mariadb-image tagging was only relevant up to CAPM3 v1.11.x
- CAPM3 v1.12+ uses [mariadb-operator](https://github.com/mariadb-operator/mariadb-operator) instead
- The general release note under `## Process` is unchanged

**OpenStack network_data.json schema** (3 files)
- Update broken `nova/latest/_downloads/.../network_data.json` links to the current working download URL

- Also see #696 for the same OpenStack link update — happy to defer that part if maintainers prefer.



Fixes #693