### PR TITLE
updated the openstack network data link

### DIFF
--- a/design/metadata-handling.md
+++ b/design/metadata-handling.md
@@ -408,7 +408,7 @@ while `networkData` will be rendered into a map equivalent of
 [Nova network_data.json](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata).
 On the target node, the network data will be rendered as a json object that
 follows the format definition that can be found
-[over here](https://docs.openstack.org/nova/latest/_downloads/9119ca7ac90aa2990e762c08baea3a36/network_data.json).
+[over here](https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json).
 
 #### Metadata Specifications
 

--- a/docs/user-guide/src/bmo/instance_customization.md
+++ b/docs/user-guide/src/bmo/instance_customization.md
@@ -79,7 +79,7 @@ spec:
 ```
 
 [network_data]: https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata
-[network_data schema]: https://docs.openstack.org/nova/latest/_downloads/9119ca7ac90aa2990e762c08baea3a36/network_data.json
+[network_data schema]: https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json
 
 ### NetworkData examples
 

--- a/docs/user-guide/src/capm3/metal3machine.md
+++ b/docs/user-guide/src/capm3/metal3machine.md
@@ -36,7 +36,7 @@ The fields are:
   [doc](https://cluster-api.sigs.k8s.io/developer/providers/contracts/clusterctl#ownerreferences-chain)).
   The content of the secret should be a yaml equivalent of a json object that
   follows the format definition that can be found
-  [here](https://docs.openstack.org/nova/latest/_downloads/9119ca7ac90aa2990e762c08baea3a36/network_data.json).
+  [here](https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json).
 
 - **hostSelector** -- Specify criteria for matching labels on `BareMetalHost`
   objects. This can be used to limit the set of available `BareMetalHost`


### PR DESCRIPTION
## Summary
Update broken OpenStack Nova network_data.json documentation links reported in https://github.com/metal3-io/metal3-docs/issues/693.

## Problem
The previous link to `network_data.json` in the OpenStack Nova docs 
was returning 404 / outdated content.

## Changes
Replaced outdated link with the current working URL across:
- `metal3machine.md`
- `instance_customization.md`  
- `metadata-handling.md`

Fixes https://github.com/metal3-io/metal3-docs/issues/693.




