### PR TITLE
:seedling: Add environment.metal3.io/ironic-standalone-operator: true to hack/quick-start/ironic/certificate.yaml

### DIFF
--- a/hack/quick-start/ironic/certificate.yaml
+++ b/hack/quick-start/ironic/certificate.yaml
@@ -35,6 +35,10 @@ metadata:
   name: ironic-cert
   namespace: baremetal-operator-system
 spec:
+  secretTemplate:
+    labels:
+      environment.metal3.io/ironic-standalone-operator: "true"
+  commonName: ironic-cert
   ipAddresses:
   - 192.168.222.2
   dnsNames:


### PR DESCRIPTION
Add `environment.metal3.io/ironic-standalone-operator: true` to hack/quick-start/ironic/certificate.yaml. This is required for newer IRSO versions. This should fix the quick-start test. 