### PR TITLE
:seedling: Fix PR Quick start action permissions

### DIFF
--- a/.github/workflows/pr-test-quick-start-guide.yml
+++ b/.github/workflows/pr-test-quick-start-guide.yml
@@ -6,10 +6,13 @@ on:
     branches:
     - main
     paths:
-    - "docs/user-guide/src/quick-start.md"
-    - "hack/quick-start/**"
+    - 'docs/user-guide/src/quick-start.md'
+    - 'hack/quick-start/**'
+    - '.github/workflows/test-quick-start-guide.yml'
+    - '.github/workflows/pr-test-quick-start-guide.yml'
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   e2e-test:


### PR DESCRIPTION
I noticed PR job is not working because of miss match in permissions. Update PR action's permission  to match the workflow that is being called from it. 