### PR TITLE
Fix broken Ansible documentation link in physical network API design doc

### DIFF
--- a/design/physical-network-api-prototype.md
+++ b/design/physical-network-api-prototype.md
@@ -64,7 +64,7 @@ discussed.
 ## Proposal
 
 The prototype should explore the re-use of [Ansible
-Networking](https://docs.ansible.com/projects/ansible/latest/network/index.html)
+Networking](https://docs.ansible.com/ansible/latest/network/getting_started/index.html)
  to perform device configuration.  Ansible includes modules for managing the
 configuration of many different network devices.  Creation of CRDs in this new
 API can use modeling from Ansible as inspiration, particularly if there is any
@@ -239,7 +239,7 @@ possible future prototypes can be added to this section.
 
 ## References
 
-- <https://docs.ansible.com/projects/ansible/latest/network/index.html>
+- <https://docs.ansible.com/ansible/latest/network/getting_started/index.html>
 - <https://networking-ansible.readthedocs.io/en/latest/>
 - <https://github.com/operator-framework/operator-sdk>
 - <https://github.com/zalando-incubator/kopf>


### PR DESCRIPTION
Description

  ## What this PR does
  Fixes a broken Ansible documentation link in the physical network API prototype design document that was
  returning a 404 error.

  ## Changes
  - Updated Ansible Networking documentation URL from the deprecated path to the current one
  - Old URL: `https://docs.ansible.com/projects/ansible/latest/network/index.html` (404)
  - New URL: `https://docs.ansible.com/ansible/latest/network/getting_started/index.html` (working)
  - Fixed both occurrences in the file (proposal section and references section)

  ## Testing
  - Verified the new URL is accessible and points to the correct Ansible network automation documentation
  - Confirmed both link occurrences were updated

  Fixes #706