### PR TITLE
Replace unhelpful [here] links with descriptive one

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ come talk to us!
   for the project related announcements, discussions and questions.
 * Come and meet us in our weekly community meetings on every
   Wednesday at 14:00 UTC on [Zoom](https://zoom.us/j/97255696401?pwd=ZlJMckNFLzdxMDNZN2xvTW5oa2lCZz09)
-* If you missed the previous community meeting, you can still find the notes
-  [here](https://docs.google.com/document/d/1IkEIh-ffWY3DaNX3aFcAxGbttdEY_symo7WAGmzkWhU/edit)
-  and recordings [here](https://www.youtube.com/playlist?list=PL2h5ikWC8viJY4SNeOpCKTyERToTbJJJA)
+* If you missed the previous community meeting, you can still find the notes in
+  [Google document](https://docs.google.com/document/d/1IkEIh-ffWY3DaNX3aFcAxGbttdEY_symo7WAGmzkWhU/edit)
+  and recordings [on YouTube](https://www.youtube.com/playlist?list=PL2h5ikWC8viJY4SNeOpCKTyERToTbJJJA)
 
 ## Code of Conduct
 

--- a/design/_template.md
+++ b/design/_template.md
@@ -67,7 +67,7 @@ To get started with this template:
     changes.
 
 The canonical place for the latest set of instructions (and the likely
-source of this file) is [here](/design/_template.md).
+source of this file) is [design/\_template.md](/design/_template.md).
 
 ## Status
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,8 +37,8 @@ is consumed by the Mdbook, and defines the content structure.
 
 All parameters and configurations of the user-guide is done via book.toml.
 These include output parameters, redirects, metadata such as title,
-description, authors, language, etc. More information on that can be found
-[here](https://rust-lang.github.io/mdBook/format/config.html).
+description, authors, language, etc. More information on that can be found in
+[mdBook configuration documentation](https://rust-lang.github.io/mdBook/format/config.html).
 
 ### SUMMARY.md
 

--- a/docs/presentations/README.md
+++ b/docs/presentations/README.md
@@ -48,7 +48,7 @@ cp ${your_presentation_directory}/* ${revealjs_directory}
 ```
 
 For full scale revealjs deployment refer
-[here](https://revealjs.com/installation/#full-setup)
+[revealjs setup guide](https://revealjs.com/installation/#full-setup).
 
 Now you can simply edit the presentation html, markdown files(when using an
 external markdown file) to build on top of the presentation.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -68,7 +68,7 @@ MDBOOK_BIN := $(BIN_DIR)/mdbook
 Before submitting document change, you can run the same mdbook binary to preview
 the book.
 
-1. Install the mdbook by following official docs [here](https://rust-lang.github.io/mdBook/)
+1. Install the mdbook by following [official docs](https://rust-lang.github.io/mdBook/)
 
 1. You can use serve command to preview the user-guide running at localhost:3000
 

--- a/docs/user-guide/src/capm3/data_sources.md
+++ b/docs/user-guide/src/capm3/data_sources.md
@@ -15,7 +15,7 @@ big picture, so for up to date documentation of CAPI resources, refer to the
 official docs.**
 
 Visualization of relationships between metal3 resources can be found for example
-[here](https://github.com/metal3-io/cluster-api-provider-metal3/issues/1358).
+in [issue 1358](https://github.com/metal3-io/cluster-api-provider-metal3/issues/1358).
 **Note that the graph is not perfect and there can be missing information.**
 
 The example values in this document are from a cluster deployed with

--- a/docs/user-guide/src/capm3/installation_guide.md
+++ b/docs/user-guide/src/capm3/installation_guide.md
@@ -12,11 +12,12 @@ install them yourself.
 1. Install `clusterctl`, refer to Cluster API
    [book](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl)
    for installation instructions.
-1. Install `kustomize`, refer to official instructions
-   [here](https://kubectl.docs.kubernetes.io/installation/kustomize/).
-1. Install Ironic, refer to [this page](../ironic/ironic_installation.html).
+1. Install `kustomize`, refer to
+   [official instructions](https://kubectl.docs.kubernetes.io/installation/kustomize/).
+1. Install Ironic, refer to
+   [Ironic installation guide](../ironic/ironic_installation.html).
 1. Install Baremetal Operator, refer to
-   [this page](../bmo/install_baremetal_operator.html).
+   [BMO installation guide](../bmo/install_baremetal_operator.html).
 1. Install Cluster API core components i.e., core, bootstrap and control-plane
    providers. This will also install cert-manager, if it is not already
    installed.

--- a/docs/user-guide/src/capm3/metal3machine.md
+++ b/docs/user-guide/src/capm3/metal3machine.md
@@ -35,8 +35,8 @@ The fields are:
   ensure that the secret belongs to the cluster ownerReference tree (see
   [doc](https://cluster-api.sigs.k8s.io/developer/providers/contracts/clusterctl#ownerreferences-chain)).
   The content of the secret should be a yaml equivalent of a json object that
-  follows the format definition that can be found
-  [here](https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json).
+  follows the format definition that can be found in
+  [network data schema](https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json).
 
 - **hostSelector** -- Specify criteria for matching labels on `BareMetalHost`
   objects. This can be used to limit the set of available `BareMetalHost`

--- a/docs/user-guide/src/capm3/pivoting.md
+++ b/docs/user-guide/src/capm3/pivoting.md
@@ -10,8 +10,8 @@ Cluster API Provider Metal3 (CAPM3) implements support for CAPI's
 CAPI Pivoting feature is a process of moving the provider components and
 declared Cluster API resources from a source management cluster to a target
 management cluster by using the `clusterctl` functionality called "move". More
-information about the general CAPI "move" functionality can be found
-[here](https://cluster-api.sigs.k8s.io/clusterctl/commands/move.html).
+information about the general CAPI "move" functionality can be found in
+[move command reference](https://cluster-api.sigs.k8s.io/clusterctl/commands/move.html).
 
 In Metal3, pivoting is performed by using the CAPI `clusterctl` tool provided
 by Cluster-API project. `clusterctl` recognizes pivoting as move. During the

--- a/docs/user-guide/src/project-overview.md
+++ b/docs/user-guide/src/project-overview.md
@@ -59,9 +59,9 @@ can be used to assign IP addresses to the hosts.
 ## Requirements
 
 - Server(s) with baseboard management capabilities (i.e. Redfish, iDRAC, IPMI,
-  etc.). For development you can use virtual machines with Sushy-tools. More
-  information [here](./bmo/supported_hardware.md).
-- An Ironic instance. More information [here](./ironic/introduction.md).
+  etc.). For development you can use virtual machines with Sushy-tools. For
+  more information see [supported hardware](./bmo/supported_hardware.md).
+- An Ironic instance. See [introduction in Ironic](./ironic/introduction.md).
 - A Kubernetes cluster (the management cluster) where the user stores and
   manages the Metal3 resources. A [kind cluster](https://kind.sigs.k8s.io/) is
   enough for bootstrapping or development.

--- a/docs/user-guide/src/security_policy.md
+++ b/docs/user-guide/src/security_policy.md
@@ -61,8 +61,8 @@ benefits of open engagement with the community.
 If the CVSS score is over ~7.0 (high severity score), fixes will typically
 receive an out-of-band release.
 
-More information can be found about severity scores
-[here](https://www.first.org/cvss/specification-document#i5).
+More information about severity scores can be found in
+[CVSS specification](https://www.first.org/cvss/specification-document#i5).
 
 Note: CVSS is convenient but imperfect. Ultimately, the SL has discretion
 on classifying the severity of a vulnerability.
@@ -87,8 +87,8 @@ privileges the advisory will be created in cooperation with a repository admin.
 SL will have to request a CVE number for the security advisory.
 As GitHub is a CVE Numbering authority (CNA) there is an option to either use an
 existing CVE number or request a new one from GitHub. More about the GitHub
-security advisory and the CVE numbering process can be found
-[here](https://docs.github.com/en/code-security/concepts/vulnerability-reporting-and-management/about-repository-security-advisories).
+security advisory and the CVE numbering process can be found in
+[GitHub documentation](https://docs.github.com/en/code-security/concepts/vulnerability-reporting-and-management/about-repository-security-advisories).
 
 The original reporter(s) of the security issue has to be notified about the
 release date of the fix and the advisory and about both the content of the fix

--- a/processes/roadmap.md
+++ b/processes/roadmap.md
@@ -1,7 +1,7 @@
 # Metal3 Roadmap
 
-The Metal3 Roadmap is maintained as a Github project and can be found
-[here](https://github.com/orgs/metal3-io/projects/8).
+The Metal3 Roadmap is maintained as a
+[Github project](https://github.com/orgs/metal3-io/projects/8).
 
 ## Description
 

--- a/security/self-assessment.md
+++ b/security/self-assessment.md
@@ -308,10 +308,10 @@ Detailed from the
 * Come and meet us in our weekly community meetings on every
    Wednesday at 14:00 UTC on
    [Zoom](https://zoom.us/j/97255696401?pwd=ZlJMckNFLzdxMDNZN2xvTW5oa2lCZz09)
-* If you missed the previous community meeting, you can still find the notes
-   [here](https://docs.google.com/document/d/1IkEIh-ffWY3DaNX3aFcAxGbttdEY_symo7WAGmzkWhU/edit)
+* If you missed the previous community meeting, you can still find the notes in
+   [Google document](https://docs.google.com/document/d/1IkEIh-ffWY3DaNX3aFcAxGbttdEY_symo7WAGmzkWhU/edit)
    and recordings
-   [here](https://www.youtube.com/playlist?list=PL2h5ikWC8viJY4SNeOpCKTyERToTbJJJA)
+   [on YouTube](https://www.youtube.com/playlist?list=PL2h5ikWC8viJY4SNeOpCKTyERToTbJJJA)
 * Find more information about Metal3 on [Metal3 Website](https://metal3.io)
 
 ### Ecosystem


### PR DESCRIPTION
This will be a failure in the next version of markdownlint-cli2.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
