### PR TITLE
Remove MariaDB references from docs after mariadb-image archival

### DIFF
--- a/docs/user-guide/src/bmo/install_baremetal_operator.md
+++ b/docs/user-guide/src/bmo/install_baremetal_operator.md
@@ -282,10 +282,6 @@ for you.
 * certificates exist
 * IRONIC_CERT_FILE : Ironic certificate path
 * IRONIC_KEY_FILE : Ironic certificate key path
-* MARIADB_KEY_FILE: Path to the key of MariaDB
-* MARIADB_CERT_FILE:  Path to the cert of MariaDB
-* MARIADB_CAKEY_FILE: Path to the CA key of MariaDB
-* MARIADB_CACERT_FILE: Path to the CA certificate of MariaDB
 
 Before version 0.5.0, Ironic Inspector parameters were also used:
 

--- a/docs/user-guide/src/ironic/ironic_installation.md
+++ b/docs/user-guide/src/ironic/ironic_installation.md
@@ -23,8 +23,6 @@ A few other containers are optional:
 - dnsmasq (to support DHCP on the provisioning network and to implement
   network boot via iPXE)
 - ironic-log-watch (to provide access to the deployment ramdisk logs)
-- mariadb (the provisioning service database; SQLite can be used as
-  a lightweight alternative)
 - ironic-inspector (the auxiliary inspection service - only used in older
   versions of Metal3)
 
@@ -117,7 +115,6 @@ installation script. This will start below containers:
 - ipa-downloader
 - dnsmasq
 - httpd
-- mariadb; if `IRONIC_USE_MARIADB` = "true"
 
 If in-cluster ironic installation, we used different manifests for TLS and
 basic auth, here we are exporting environment variables for enabling/disabling

--- a/docs/user-guide/src/version_support.md
+++ b/docs/user-guide/src/version_support.md
@@ -149,32 +149,32 @@ The table describes which branches/image-tags are tested in each periodic CI tes
 
 <!-- markdownlint-disable MD013 -->
 
-| INTEGRATION TESTS                                               | CAPM3 branch | IPAM branch  | BMO branch/tag | Keepalived tag | MariaDB tag | Ironic tag |
-| --------------------------------------------------------------- | ------------ | ------------ | -------------- | -------------- | ----------- | ---------- |
-| metal3-periodic-ubuntu/centos-e2e-integration-test-main         | main         | main         | main           | latest         | latest      | latest     |
-| metal3_periodic_main_integration_test_ubuntu/centos             | main         | main         | main           | latest         | latest      | latest     |
-| metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-13 | release-1.13 | release-1.13 | release-0.13   | latest         | latest      | v35.0.0    |
-| metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-12 | release-1.12 | release-1.12 | release-0.12   | latest         | latest      | v33.0.0    |
-| metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-11 | release-1.11 | release-1.11 | release-0.11   | latest         | latest      | v31.0.0    |
+| INTEGRATION TESTS                                               | CAPM3 branch | IPAM branch  | BMO branch/tag | Keepalived tag | Ironic tag |
+| --------------------------------------------------------------- | ------------ | ------------ | -------------- | -------------- | ---------- |
+| metal3-periodic-ubuntu/centos-e2e-integration-test-main         | main         | main         | main           | latest         | latest     |
+| metal3_periodic_main_integration_test_ubuntu/centos             | main         | main         | main           | latest         | latest     |
+| metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-13 | release-1.13 | release-1.13 | release-0.13   | latest         | v35.0.0    |
+| metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-12 | release-1.12 | release-1.12 | release-0.12   | latest         | v33.0.0    |
+| metal3-periodic-ubuntu/centos-e2e-integration-test-release-1-11 | release-1.11 | release-1.11 | release-0.11   | latest         | v31.0.0    |
 
-| FEATURE AND E2E TESTS                                            | CAPM3 branch | IPAM branch  | BMO branch/tag | Keepalived tag | MariaDB tag | Ironic tag |
-| ---------------------------------------------------------------- | ------------ | ------------ | -------------- | -------------- | ----------- | ---------- |
-| metal3-periodic-centos-e2e-feature-test-main-pivoting            | main         | main         | main           | latest         | latest      | latest     |
-| metal3-periodic-centos-e2e-feature-test-release-1-13-pivoting    | release-1.13 | release-1.13 | release-0.13   | latest         | latest      | v35.0.0    |
-| metal3-periodic-centos-e2e-feature-test-release-1-12-pivoting    | release-1.12 | release-1.12 | release-0.12   | latest         | latest      | v33.0.0    |
-| metal3-periodic-centos-e2e-feature-test-release-1-11-pivoting    | release-1.11 | release-1.11 | release-0.11   | latest         | latest      | v31.0.0    |
-| metal3-periodic-centos-e2e-feature-test-main-remediation         | main         | main         | main           | latest         | latest      | latest     |
-| metal3-periodic-centos-e2e-feature-test-release-1-13-remediation | release-1.13 | release-1.13 | release-0.13   | latest         | latest      | v35.0.0    |
-| metal3-periodic-centos-e2e-feature-test-release-1-12-remediation | release-1.12 | release-1.12 | release-0.12   | latest         | latest      | v33.0.0    |
-| metal3-periodic-centos-e2e-feature-test-release-1-11-remediation | release-1.11 | release-1.11 | release-0.11   | latest         | latest      | v31.0.0    |
-| metal3-periodic-centos-e2e-feature-test-main-features            | main         | main         | main           | latest         | latest      | latest     |
-| metal3-periodic-centos-e2e-feature-test-release-1-13-features    | release-1.13 | release-1.13 | release-0.13   | latest         | latest      | v35.0.0    |
-| metal3-periodic-centos-e2e-feature-test-release-1-12-features    | release-1.12 | release-1.12 | release-0.12   | latest         | latest      | v33.0.0    |
-| metal3-periodic-centos-e2e-feature-test-release-1-11-features    | release-1.11 | release-1.11 | release-0.11   | latest         | latest      | v31.0.0    |
+| FEATURE AND E2E TESTS                                            | CAPM3 branch | IPAM branch  | BMO branch/tag | Keepalived tag | Ironic tag |
+| ---------------------------------------------------------------- | ------------ | ------------ | -------------- | -------------- | ---------- |
+| metal3-periodic-centos-e2e-feature-test-main-pivoting            | main         | main         | main           | latest         | latest     |
+| metal3-periodic-centos-e2e-feature-test-release-1-13-pivoting    | release-1.13 | release-1.13 | release-0.13   | latest         | v35.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-12-pivoting    | release-1.12 | release-1.12 | release-0.12   | latest         | v33.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-11-pivoting    | release-1.11 | release-1.11 | release-0.11   | latest         | v31.0.0    |
+| metal3-periodic-centos-e2e-feature-test-main-remediation         | main         | main         | main           | latest         | latest     |
+| metal3-periodic-centos-e2e-feature-test-release-1-13-remediation | release-1.13 | release-1.13 | release-0.13   | latest         | v35.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-12-remediation | release-1.12 | release-1.12 | release-0.12   | latest         | v33.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-11-remediation | release-1.11 | release-1.11 | release-0.11   | latest         | v31.0.0    |
+| metal3-periodic-centos-e2e-feature-test-main-features            | main         | main         | main           | latest         | latest     |
+| metal3-periodic-centos-e2e-feature-test-release-1-13-features    | release-1.13 | release-1.13 | release-0.13   | latest         | v35.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-12-features    | release-1.12 | release-1.12 | release-0.12   | latest         | v33.0.0    |
+| metal3-periodic-centos-e2e-feature-test-release-1-11-features    | release-1.11 | release-1.11 | release-0.11   | latest         | v31.0.0    |
 
-| EPHEMERAL TESTS                                                | CAPM3 branch | IPAM branch | BMO branch/tag | Keepalived tag | MariaDB tag | Ironic tag |
-| -------------------------------------------------------------- | ------------ | ----------- | -------------- | -------------- | ----------- | ---------- |
-| metal3_periodic_e2e_ephemeral_test_centos                      | main         | main        | main           | latest         | latest      | latest     |
+| EPHEMERAL TESTS                                                | CAPM3 branch | IPAM branch | BMO branch/tag | Keepalived tag | Ironic tag |
+| -------------------------------------------------------------- | ------------ | ----------- | -------------- | -------------- | ---------- |
+| metal3_periodic_e2e_ephemeral_test_centos                      | main         | main        | main           | latest         | latest     |
 
 <!-- markdownlint-enable MD013 -->
 


### PR DESCRIPTION
Cleans up user docs that describe the built-in MariaDB deployment, following its removal from metal3-dev-env and BMO.

- ironic/ironic_installation.md: drop the `IRONIC_USE_MARIADB` container note and reword the database bullet
- bmo/install_baremetal_operator.md: remove the `MARIADB_*_FILE` cert env entries
- version_support.md: drop the "MariaDB tag" column from the CI test matrices