### PR TITLE
Update Ironic API version requirement

### DIFF
--- a/docs/user-guide/src/bmo/install_baremetal_operator.md
+++ b/docs/user-guide/src/bmo/install_baremetal_operator.md
@@ -74,15 +74,6 @@ configurations, namely:
 
 A detailed overview of the configuration is presented in the following sections.
 
-### Notes on external Ironic
-
-When an external Ironic is used, the following requirements must be met:
-
-* Either HTTP basic or no-auth authentication must be used (Keystone is not
-  supported).
-
-* API version 1.74 (Xena release cycle) or newer must be available.
-
 ## Authenticating to Ironic
 
 Because hosts under the control of Metal³ need to contact the Ironic API during

--- a/docs/user-guide/src/ironic/introduction.md
+++ b/docs/user-guide/src/ironic/introduction.md
@@ -55,7 +55,7 @@ an externally managed Ironic instance.
 - Enabled hardware types and interfaces that match the supported Metal3 drivers
   (at least the ones you intend to use).
 - [API version](https://docs.openstack.org/ironic/latest/contributor/webapi-version-history.html)
-  1.81 (2023.1 "Antelope" release cycle) or newer must be available.
+  1.89 (2024.1 "Caracal" release cycle) or newer must be available.
 - Built-in in-band inspection (ironic-inspector is no longer supported).
 - Deploy interface `direct` enabled and used by default.
 - No-op network interface (OpenStack Networking is not supported).


### PR DESCRIPTION
It's been 1.89 for some time. Drop the terribly outdated section from
BMO docs.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
