### PR TITLE
Add Ironic authentication page to the user guide

### DIFF
--- a/docs/user-guide/src/SUMMARY.md
+++ b/docs/user-guide/src/SUMMARY.md
@@ -70,5 +70,6 @@
 - [API Reference](reference.md)
 - [Version Support](version_support.md)
 - [Security Best Practices](security/introduction.md)
+   - [Ironic Authentication](security/ironic-authentication.md)
 - [Project Security Policy](security_policy.md)
 - [Glossary](glossary.md)

--- a/docs/user-guide/src/security/introduction.md
+++ b/docs/user-guide/src/security/introduction.md
@@ -56,7 +56,8 @@ for that topic.
   [quick-start](../quick-start.md).
 - **Ironic authentication.** The Ironic `auth_strategy` modes (`noauth` versus
   `http_basic`), where BMO reads the credentials, and the fact that OpenStack
-  Identity (Keystone) is not supported. See the
+  Identity (Keystone) is not supported. See
+  [Ironic authentication](./ironic-authentication.md) and the
   [Bare Metal Operator Authentication guide](https://github.com/metal3-io/baremetal-operator/blob/main/docs/ironic-authentication.md).
 - **TLS-enabled network boot (iPXE).** Running HTTPS iPXE end to end: building
   an iPXE binary with an embedded trust anchor, how it ties into the httpd TLS

--- a/docs/user-guide/src/security/ironic-authentication.md
+++ b/docs/user-guide/src/security/ironic-authentication.md
@@ -1,0 +1,53 @@
+<!-- cSpell:ignore noauth Keystone -->
+# Ironic authentication
+
+Hosts under Metal3's control contact the Ironic API during inspection and
+provisioning, and they remain connected to the provisioning network while
+running user workloads afterwards. If that API is unauthenticated, anyone with
+access to the provisioning network can use it to manipulate your nodes.
+Requiring authentication on the Ironic API is therefore strongly advised.
+Authentication is independent of TLS (covered in
+[TLS configuration and hardening](./tls.md)); a hardened deployment uses both.
+
+## Authentication strategy
+
+Metal3 authenticates the Ironic API with HTTP Basic Authentication, and Bare
+Metal Operator (BMO) is configured with matching credentials to reach Ironic.
+
+Ironic also has a `noauth` (no-authentication) mode, but it is discouraged
+and is expected to be phased out as part of the Ironic Standalone Operator
+migration, so you should not rely on it. OpenStack Identity (Keystone)
+authentication is not supported.
+
+## How it fits together
+
+Authentication has two sides that must agree: Ironic is configured to
+require credentials, and BMO is configured to present matching ones.
+The username and password BMO sends must match what Ironic accepts.
+
+With the Ironic Standalone Operator this is wired up for you (see below).
+For the credential settings BMO reads and how to configure them, see the
+[Bare Metal Operator authentication guide](https://github.com/metal3-io/baremetal-operator/blob/main/docs/ironic-authentication.md).
+
+## With the Ironic Standalone Operator (recommended)
+
+When installing with the Ironic Standalone Operator (IrSO), credentials are
+handled for you: IrSO generates a random API password unless you supply your
+own. The credentials secret is referenced by `spec.apiCredentialsName` on the
+`Ironic` resource, and a new secret is created automatically if that field is
+empty.
+
+To provide your own credentials instead, create the secret and give it the
+label `environment.metal3.io/ironic-standalone-operator=true` so that IrSO
+recognizes it. You can read the effective credentials back from the referenced
+secret; see [Install Ironic with IrSO](../irso/install-basics.md) for the exact
+commands.
+
+## Manual and script-based installation
+
+For the older script/Kustomize-based installation, HTTP basic auth is toggled
+with `IRONIC_BASIC_AUTH` and the credentials are supplied through the
+deployment's ConfigMap and secrets. The baremetal-operator repository ships a
+ready-made `basic-auth_tls` overlay for the common case of basic auth plus TLS.
+See [the old installation process](../ironic/ironic_installation.md) for
+details; note that this path is being phased out in favour of IrSO.


### PR DESCRIPTION
Adds an "Ironic Authentication" page under the user guide's Security section, consolidating auth guidance that was previously only in the basemetal-operator repo docs.

This PR covers the supported `auth_strategy` modes (`noauth` vs. `http_basic`, and that Keystone is unsupported), the server and client sides (how ironic-image enables `http_basic` and where BMO reads credential via `METAL3_AUTH_ROOT_DIR`), the recommended IrSO path (auto-generated API credentials, `spec.apiCredentialsName`), and the manual `IRONIC_BASIC_AUTH` route.

Also links the Securitty landing page's authentication bullet to the new page and adds the SUMMARY entry.

Depends on #726 and should merge after it. /hold until then.

Until the above PR merges and this is rebase the link check will flag the security/tls.md link as broken, expected, resolved by the rebase.

Welcome any feedback on things I might have missed.